### PR TITLE
Show cluster member status

### DIFF
--- a/dkron/dashboard.go
+++ b/dkron/dashboard.go
@@ -87,15 +87,12 @@ func (a *AgentCommand) dashboardJobsHandler(w http.ResponseWriter, r *http.Reque
 	tmpl := template.Must(template.New("dashboard.html.tmpl").Funcs(funcs).ParseFiles(
 		"templates/dashboard.html.tmpl", "templates/jobs.html.tmpl", "templates/status.html.tmpl"))
 
-	l, _ := a.leaderMember()
 	data := struct {
-		Version    string
-		LeaderName string
-		Jobs       []*Job
+		Common *commonDashboardData
+		Jobs   []*Job
 	}{
-		Version:    a.Version,
-		LeaderName: l.Name,
-		Jobs:       jobs,
+		Common: newCommonDashboardData(a, a.config.NodeName),
+		Jobs:   jobs,
 	}
 
 	if err := tmpl.Execute(w, data); err != nil {
@@ -121,15 +118,12 @@ func (a *AgentCommand) dashboardExecutionsHandler(w http.ResponseWriter, r *http
 		execs = execs[len(execs)-100 : len(execs)]
 	}
 
-	l, _ := a.leaderMember()
 	data := struct {
-		Version    string
-		LeaderName string
+		Common     *commonDashboardData
 		Executions []*Execution
 		JobName    string
 	}{
-		Version:    a.Version,
-		LeaderName: l.Name,
+		Common:     newCommonDashboardData(a, a.config.NodeName),
 		Executions: execs,
 		JobName:    job,
 	}

--- a/dkron/dashboard.go
+++ b/dkron/dashboard.go
@@ -9,6 +9,21 @@ import (
 	"github.com/gorilla/mux"
 )
 
+type commonDashboardData struct {
+	Version    string
+	LeaderName string
+	MemberName string
+}
+
+func newCommonDashboardData(a *AgentCommand, nodeName string) *commonDashboardData {
+	l, _ := a.leaderMember()
+	return &commonDashboardData{
+		Version:    a.Version,
+		LeaderName: l.Name,
+		MemberName: nodeName,
+	}
+}
+
 func (a *AgentCommand) dashboardRoutes(r *mux.Router) {
 	subui := r.PathPrefix("/dashboard").Subrouter()
 	subui.HandleFunc("/", a.dashboardIndexHandler).Methods("GET")
@@ -41,16 +56,13 @@ func (a *AgentCommand) dashboardIndexHandler(w http.ResponseWriter, r *http.Requ
 	}
 	json.Unmarshal(res.Body, &ss)
 
-	l, _ := a.leaderMember()
 	data := struct {
-		Version     string
-		LeaderName  string
+		Common      *commonDashboardData
 		EtcdVersion string
 		Stats       *EtcdServerStats
 		StartTime   string
 	}{
-		Version:     a.Version,
-		LeaderName:  l.Name,
+		Common:      newCommonDashboardData(a, a.config.NodeName),
 		EtcdVersion: version.Etcdserver,
 		Stats:       ss,
 		StartTime:   ss.LeaderInfo.StartTime.Format("2/Jan/2006 15:05:05"),

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -12,7 +12,7 @@ dkron.controller('JobListCtrl', function ($scope, $http, $interval) {
     });
   };
 
-  $interval(function() {
+  var updateView = function() {
     var response = $http.get('/jobs/');
     response.success(function(data, status, headers, config) {
       $scope.updateStatus(data);
@@ -21,7 +21,7 @@ dkron.controller('JobListCtrl', function ($scope, $http, $interval) {
     response.error(function(data, status, headers, config) {
       $('#message').html('<div class="alert alert-danger fade in"><button type="button" class="close close-alert" data-dismiss="alert" aria-hidden="true">x</button>Error getting data</div>');
     });
-  }, 2000);
+  }
 
   $scope.success_count = 0;
   $scope.error_count = 0;
@@ -50,6 +50,12 @@ dkron.controller('JobListCtrl', function ($scope, $http, $interval) {
     $scope.success_count = success_count;
     $scope.error_count = error_count;
   }
+
+  $interval(function() {
+    updateView();
+  }, 2000);
+
+  updateView();
 
 });
 

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -90,7 +90,7 @@ dkron.controller('IndexCtrl', function ($scope, $http, $interval, $element) {
       }
   };
 
-  $interval(function() {
+  updateView = function() {
     var response = $http.get('/jobs/');
     response.success(function(data, status, headers, config) {
       $scope.updateGraph(data);
@@ -98,9 +98,17 @@ dkron.controller('IndexCtrl', function ($scope, $http, $interval, $element) {
 
     response.error(function(data, status, headers, config) {
       $('#message').html('<div class="alert alert-danger fade in"><button type="button" class="close close-alert" data-dismiss="alert" aria-hidden="true">x</button>Error getting data</div>');
-
     });
-  }, 2000);
+
+    var mq = $http.get('/members/');
+    mq.success(function(data, status, headers, config) {
+      $scope.members = data;
+    });
+
+    mq.error(function(data, status, headers, config) {
+      $('#message').html('<div class="alert alert-danger fade in"><button type="button" class="close close-alert" data-dismiss="alert" aria-hidden="true">x</button>Error getting data</div>');
+    });
+  }
 
   $scope.success_count = 0;
   $scope.error_count = 0;
@@ -161,4 +169,10 @@ dkron.controller('IndexCtrl', function ($scope, $http, $interval, $element) {
       data: gdata
     };
   }
+
+  $interval(function() {
+    updateView();
+  }, 2000);
+
+  updateView();
 });

--- a/templates/dashboard.html.tmpl
+++ b/templates/dashboard.html.tmpl
@@ -4,7 +4,7 @@
     <title>Dkron</title>
 
     <link rel="stylesheet" href="/css/bootstrap-custom.min.css">
-    <link rel="stylesheet" href="/css/font-awesome-4.0.3.css">
+    <link rel="stylesheet" href="/css/font-awesome.css">
     <link rel="stylesheet" href="/css/app.css">
 
     <script src="/bower_components/angular/angular.js"></script>

--- a/templates/dashboard.html.tmpl
+++ b/templates/dashboard.html.tmpl
@@ -75,10 +75,13 @@
         <div class="container text-center">
             <ul class="nav">
               <li>
-                <p class="navbar-text">Dkron v{{ .Version }}</p>
+                <p class="navbar-text">Dkron v{{ .Common.Version }}</p>
               </li>
               <li>
-                <p class="navbar-text">Leader: {{ .LeaderName }}</p>
+                <p class="navbar-text">Member: {{ .Common.MemberName }}</p>
+              </li>
+              <li>
+                <p class="navbar-text">Leader: {{ .Common.LeaderName }}</p>
               </li>
             </ul>
         </div>

--- a/templates/executions.html.tmpl
+++ b/templates/executions.html.tmpl
@@ -6,24 +6,24 @@
   </div>
 
   <table class="table table-striped">
-	<tr>
-	  <th>Job</th>
-	  <th>Started At</th>
-	  <th>Finished At</th>
-	  <th>Node</th>
-	  <th>Output</th>
-	  <th>Success</th>
-	</tr>
-        {{ range $ex := .Executions }}
-        <tr>
-	  <td>{{ $ex.JobName }}</td>
-	  <td>{{ $ex.StartedAt }}</td>
-	  <td>{{ $ex.FinishedAt }}</td>
-	  <td>{{ $ex.NodeName }}</td>
-	  <td>{{ html $ex.Output }}</td>
-	  <td>{{ $ex.Success }}</td>
-	</tr>
-	{{ end }}
-      </table>
+    <tr>
+      <th>Job</th>
+      <th>Started At</th>
+      <th>Finished At</th>
+      <th>Node</th>
+      <th>Output</th>
+      <th>Success</th>
+    </tr>
+    {{ range $ex := .Executions }}
+    <tr>
+      <td>{{ $ex.JobName }}</td>
+      <td>{{ $ex.StartedAt }}</td>
+      <td>{{ $ex.FinishedAt }}</td>
+      <td>{{ $ex.NodeName }}</td>
+      <td>{{ html $ex.Output }}</td>
+      <td>{{ $ex.Success }}</td>
+    </tr>
+    {{ end }}
+  </table>
 </div>
 {{end}}

--- a/templates/index.html.tmpl
+++ b/templates/index.html.tmpl
@@ -13,7 +13,7 @@
   </div>
 
   <div class="row">
-    <h2>Members</h2>
+    <h2>Nodes</h2>
     <table class="table table-striped">
       <tr>
         <th>Name</th>

--- a/templates/index.html.tmpl
+++ b/templates/index.html.tmpl
@@ -13,6 +13,30 @@
   </div>
 
   <div class="row">
+    <h2>Members</h2>
+    <table class="table table-striped">
+      <tr>
+        <th>Name</th>
+        <th>Address</th>
+        <th>Port</th>
+        <th>Status</th>
+        <th>Tags</th>
+      </tr>
+      <tr ng-repeat="member in members">
+        <td ng-bind="member.Name"></td>
+        <td ng-bind="member.Addr"></td>
+        <td ng-bind="member.Port"></td>
+        <td ng-bind="member.Status"></td>
+        <td>
+          <div ng-repeat="(key, value) in member.Tags">
+            <span ng-bind="key + ': '"></span><span ng-bind="value"></span>
+          </div>
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="row">
     <h2>etcd</h2>
 
     <div class="col-md-3">


### PR DESCRIPTION
Visual representation of the response from `/members` showing the cluster members info.

Implemented in the client (angular).

Also implements a refactor on how we pass common data to the templates in order to remove repeated code and reduce LOC