### PR TITLE
Optional pretty format API responses

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -4,6 +4,7 @@ You can communicate with dkron using a RESTful JSON API over HTTP. dkron nodes u
 
 dkron implements a RESTful JSON API over HTTP to communicate with software clients. dkron listens in port `8080` by default. All examples in this section assume that you're using the default port.
 
+Default API responses are unformatted JSON add the `pretty=true` param to format the response.
 
 ## Status
 

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -4,3 +4,4 @@ You can communicate with dkron using a RESTful JSON API over HTTP. dkron nodes u
 
 dkron implements a RESTful JSON API over HTTP to communicate with software clients. dkron listens in port `8080` by default. All examples in this section assume that you're using the default port.
 
+Default API responses are unformatted JSON add the `pretty=true` param to format the response.


### PR DESCRIPTION
This takes the `pretty` param to show indented JSON responses when quering API.

Also send common json headers.

Fixes #16 