### PR TITLE
Fix RPC address from clients

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
-dkron2: go run *.go agent -server -node=dkron2 -bind=127.0.0.1:5001 -http-addr=:8080 -backend=consul -backend-machine=:8500 -rpc-addr=:8686 -debug=true
-dkron3: go run *.go agent -server -node=dkron3 -bind=127.0.0.1:5002 -http-addr=:8081 -backend=consul -backend-machine=:8500 -rpc-addr=:8687 -debug=true
-dkron4: go run *.go agent -server -node=dkron4 -bind=127.0.0.1:5003 -http-addr=:8082 -backend=consul -backend-machine=:8500 -rpc-addr=:8688 -debug=true
+dkron2: go run *.go agent -server -node=dkron2 -bind=127.0.0.1:5001 -http-addr=:8080 -backend=consul -backend-machine=:8500 -rpc-port=8686 -debug=true
+dkron3: go run *.go agent -server -node=dkron3 -bind=127.0.0.1:5002 -http-addr=:8081 -backend=consul -backend-machine=:8500 -rpc-port=8687 -debug=true
+dkron4: go run *.go agent -server -node=dkron4 -bind=127.0.0.1:5003 -http-addr=:8082 -backend=consul -backend-machine=:8500 -rpc-port=8688 -debug=true
 dkron5: go run *.go agent -node=dkron5 -bind=127.0.0.1:5004 -debug=true
 dkron6: go run *.go agent -node=dkron6 -bind=127.0.0.1:5005 -debug=true

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -73,7 +73,8 @@ Options:
   -encrypt                        Key for encrypting network traffic.
                                   Must be a base64-encoded 16-byte key.
   -ui-dir                         Directory from where to serve Web UI
-  -rpc-addr=:6868                 RPC Address used to communicate with clients. Only used when server.
+  -rpc-port=6868                  RPC Port used to communicate with clients. Only used when server.
+                                  The RPC IP Address will be the same as the bind address.
 
   -mail-host                      Mail server host address to use for notifications.
   -mail-port                      Mail server port.
@@ -126,8 +127,7 @@ func (a *AgentCommand) readConfig(args []string) *Config {
 	viper.SetDefault("debug", cmdFlags.Bool("debug", false, "output debug log"))
 	cmdFlags.String("ui-dir", ".", "directory to serve web UI")
 	viper.SetDefault("ui_dir", cmdFlags.Lookup("ui-dir").Value)
-	cmdFlags.String("rpc-addr", ":6868", "RPC address")
-	viper.SetDefault("rpc_addr", cmdFlags.Lookup("rpc-addr").Value)
+	viper.SetDefault("rpc_port", cmdFlags.Int("rpc-port", 6868, "RPC port"))
 
 	// Notifications
 	cmdFlags.String("mail-host", "", "notification mail server host")
@@ -186,7 +186,7 @@ func (a *AgentCommand) readConfig(args []string) *Config {
 		Keyspace:        viper.GetString("keyspace"),
 		EncryptKey:      viper.GetString("encrypt"),
 		UIDir:           viper.GetString("ui_dir"),
-		RPCAddr:         viper.GetString("rpc_addr"),
+		RPCPort:         viper.GetInt("rpc_port"),
 
 		MailHost:     viper.GetString("mail_host"),
 		MailPort:     uint16(viper.GetInt("mail_port")),
@@ -201,7 +201,9 @@ func (a *AgentCommand) readConfig(args []string) *Config {
 }
 
 // setupAgent is used to create the agent we use
-func (a *AgentCommand) setupSerf(config *Config) *serf.Serf {
+func (a *AgentCommand) setupSerf() *serf.Serf {
+	config := a.config
+
 	bindIP, bindPort, err := config.AddrParts(config.BindAddr)
 	if err != nil {
 		a.Ui.Error(fmt.Sprintf("Invalid bind address: %s", err))
@@ -346,8 +348,8 @@ func (a *AgentCommand) setupSerf(config *Config) *serf.Serf {
 	serfConfig.EventCh = a.eventCh
 
 	// Start Serf
-	a.Ui.Output("Starting Serf agent...")
-	log.Info("agent: Serf agent starting")
+	a.Ui.Output("Starting Dkron agent...")
+	log.Info("agent: Dkron agent starting")
 
 	serfConfig.LogOutput = ioutil.Discard
 	serfConfig.MemberlistConfig.LogOutput = ioutil.Discard
@@ -379,7 +381,7 @@ func UnmarshalTags(tags []string) (map[string]string, error) {
 
 func (a *AgentCommand) Run(args []string) int {
 	a.config = a.readConfig(args)
-	if a.serf = a.setupSerf(a.config); a.serf == nil {
+	if a.serf = a.setupSerf(); a.serf == nil {
 		log.Fatal("agent: Can not setup serf")
 	}
 	a.join(a.config.StartJoin, true)
@@ -594,7 +596,7 @@ func (a *AgentCommand) eventLoop() {
 						"at":      query.LTime,
 					}).Debug("agent: RPC Config requested")
 
-					query.Respond([]byte(a.config.RPCAddr))
+					query.Respond([]byte(a.getRPCAddr()))
 				}
 			}
 
@@ -779,4 +781,12 @@ func (a *AgentCommand) setExecution(payload []byte) *Execution {
 	}
 
 	return &ex
+}
+
+// This function is called when a client request the RPCAddress
+// of the current member.
+func (a *AgentCommand) getRPCAddr() string {
+	addr, _ := net.ResolveTCPAddr("tcp", a.config.BindAddr)
+
+	return fmt.Sprintf("%s:%d", addr.IP.String(), a.config.RPCPort)
 }

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -269,8 +269,8 @@ func (a *AgentCommand) setupSerf() *serf.Serf {
 		} else {
 			// If there is a bind IP, ensure it is available
 			found := false
-			for _, a := range addrs {
-				addr, ok := a.(*net.IPNet)
+			for _, ad := range addrs {
+				addr, ok := ad.(*net.IPNet)
 				if !ok {
 					continue
 				}
@@ -786,7 +786,8 @@ func (a *AgentCommand) setExecution(payload []byte) *Execution {
 // This function is called when a client request the RPCAddress
 // of the current member.
 func (a *AgentCommand) getRPCAddr() string {
-	addr, _ := net.ResolveTCPAddr("tcp", a.config.BindAddr)
+	bindIp, _, _ := a.config.AddrParts(a.config.BindAddr)
 
-	return fmt.Sprintf("%s:%d", addr.IP.String(), a.config.RPCPort)
+	println(a.config.BindAddr)
+	return fmt.Sprintf("%s:%d", bindIp, a.config.RPCPort)
 }

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -788,6 +788,5 @@ func (a *AgentCommand) setExecution(payload []byte) *Execution {
 func (a *AgentCommand) getRPCAddr() string {
 	bindIp, _, _ := a.config.AddrParts(a.config.BindAddr)
 
-	println(a.config.BindAddr)
 	return fmt.Sprintf("%s:%d", bindIp, a.config.RPCPort)
 }

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -82,7 +82,6 @@ func TestAgentCommandElectLeader(t *testing.T) {
 	args := []string{
 		"-bind", a1Addr,
 		"-join", a2Addr,
-		"-rpc-addr", testutil.GetBindAddr().String() + ":6868",
 		"-node", "test1",
 		"-server",
 		"-debug",
@@ -112,7 +111,6 @@ func TestAgentCommandElectLeader(t *testing.T) {
 	args2 := []string{
 		"-bind", a2Addr,
 		"-join", a1Addr,
-		"-rpc-addr", testutil.GetBindAddr().String() + ":6868",
 		"-node", "test2",
 		"-server",
 		"-debug",
@@ -184,7 +182,6 @@ func Test_processFilteredNodes(t *testing.T) {
 	args := []string{
 		"-bind", a1Addr,
 		"-join", a2Addr,
-		"-rpc-addr", testutil.GetBindAddr().String() + ":6868",
 		"-node", "test1",
 		"-server",
 		"-tag", "role=test",
@@ -209,7 +206,6 @@ func Test_processFilteredNodes(t *testing.T) {
 	args2 := []string{
 		"-bind", a2Addr,
 		"-join", a1Addr,
-		"-rpc-addr", testutil.GetBindAddr().String() + ":6868",
 		"-node", "test2",
 		"-server",
 		"-tag", "role=test",
@@ -273,7 +269,6 @@ func TestEncrypt(t *testing.T) {
 
 	args := []string{
 		"-bind", testutil.GetBindAddr().String(),
-		"-rpc-addr", testutil.GetBindAddr().String() + ":6868",
 		"-node", "test1",
 		"-server",
 		"-tag", "role=test",

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -26,7 +26,6 @@ func setupAPITest(t *testing.T) (chan<- struct{}, <-chan int) {
 
 	args := []string{
 		"-bind", testutil.GetBindAddr().String(),
-		"-rpc-addr", testutil.GetBindAddr().String() + ":6868",
 		"-http-addr", "127.0.0.1:8090",
 		"-node", "test",
 		"-server",

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	StartJoin             AppendSliceValue
 	Keyspace              string
 	UIDir                 string
-	RPCAddr               string
+	RPCPort               int
 
 	MailHost     string
 	MailPort     uint16

--- a/dkron/rpc.go
+++ b/dkron/rpc.go
@@ -70,7 +70,7 @@ func listenRPC(a *AgentCommand) {
 	}
 
 	log.WithFields(logrus.Fields{
-		"rpc_addr": a.config.RPCAddr,
+		"rpc_addr": a.getRPCAddr(),
 	}).Debug("rpc: Registering RPC server")
 
 	rpc.Register(r)
@@ -91,7 +91,7 @@ func listenRPC(a *AgentCommand) {
 	// workaround
 	http.DefaultServeMux = oldMux
 
-	l, e := net.Listen("tcp", a.config.RPCAddr)
+	l, e := net.Listen("tcp", a.getRPCAddr())
 	if e != nil {
 		log.Fatal("listen error:", e)
 	}

--- a/dkron/rpc_test.go
+++ b/dkron/rpc_test.go
@@ -27,11 +27,9 @@ func TestRPCExecutionDone(t *testing.T) {
 	}
 
 	aAddr := testutil.GetBindAddr().String()
-	rpcAddr := testutil.GetBindAddr().String() + ":6868"
 
 	args := []string{
 		"-bind", aAddr,
-		"-rpc-addr", rpcAddr,
 		"-node", "test1",
 		"-server",
 		"-debug",
@@ -65,7 +63,7 @@ func TestRPCExecutionDone(t *testing.T) {
 	}
 
 	rc := &RPCClient{
-		ServerAddr: rpcAddr,
+		ServerAddr: a.getRPCAddr(),
 	}
 
 	rc.callExecutionDone(testExecution)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -42,4 +42,4 @@ Settings for dkron can be specified in three ways: Using a `config/dkron.json` c
 
 * `-ui-dir` - Directory from where to serve web UI.
 
-* `-rpc-addr` - The address that Dkron will bind to for the agent's RPC server, defaults to ":6868".
+* `-rpc-port` - The port that Dkron will use to bind for the agent's RPC server, defaults to 6868. The RPC address will be the bind address.


### PR DESCRIPTION
This limits the RPC parameter to just the port. We want to use the bind
IP always for agents communications.