### PR TITLE
Remove not needed var

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -417,14 +417,8 @@ func (a *AgentCommand) handleSignals() int {
 	}
 	a.Ui.Output(fmt.Sprintf("Caught signal: %v", sig))
 
-	// Check if we should do a graceful leave
-	graceful := false
-	if sig == syscall.SIGTERM || sig == os.Interrupt {
-		graceful = true
-	}
-
 	// Bail fast if not doing a graceful leave
-	if !graceful {
+	if sig != syscall.SIGTERM && sig != os.Interrupt {
 		return 1
 	}
 


### PR DESCRIPTION
As you don't do anything else with this var. I think it's not needed.

Maybe you can move the condition to `a.isGraceful(sig)` for more redeable code. But that's your call :)