### PR TITLE
Refactor leader election

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - go get github.com/Masterminds/glide
 
 before_script:
-  - scripts/travis_etcd.sh 2.1.1
+  - scripts/travis_etcd.sh 2.2.5
 
 script:
   - ./etcd/etcd >/dev/null 2>&1 &

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -477,8 +477,8 @@ func (a *AgentCommand) participate() {
 	go func() {
 		for {
 			a.runForElection()
-			time.Sleep(defaultRecoverTime)
 			// retry
+			time.Sleep(defaultRecoverTime)
 		}
 	}()
 }
@@ -488,6 +488,7 @@ func (a *AgentCommand) runForElection() {
 	log.Info("agent: Running for election")
 	electedCh, errCh, err := a.candidate.RunForElection()
 	if err != nil {
+		log.WithError(err).Error("Can't run for election, store is probably down")
 		return
 	}
 	for {
@@ -507,7 +508,7 @@ func (a *AgentCommand) runForElection() {
 			}
 
 		case err := <-errCh:
-			log.Error(err)
+			log.WithError(err).Error("Leader election failed, channel is probably closed")
 			return
 		}
 	}

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -465,11 +465,11 @@ func (a *AgentCommand) Synopsis() string {
 }
 
 func (a *AgentCommand) participate() {
-	foo := leadership.NewCandidate(a.store.Client, a.store.LeaderKey(), a.config.NodeName, defaultLeaderTTL)
+	candidate := leadership.NewCandidate(a.store.Client, a.store.LeaderKey(), a.config.NodeName, defaultLeaderTTL)
 
 	go func() {
 		for {
-			a.runForElection(foo)
+			a.runForElection(candidate)
 			time.Sleep(defaultRecoverTime)
 			// retry
 		}

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -1,7 +1,6 @@
 package dkron
 
 import (
-	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"expvar"
@@ -177,7 +176,6 @@ func (a *AgentCommand) readConfig(args []string) *Config {
 	nodeName := viper.GetString("node_name")
 
 	if server {
-		data := []byte(nodeName + fmt.Sprintf("%s", time.Now()))
 		tags["server"] = "true"
 	}
 
@@ -512,7 +510,7 @@ func (a *AgentCommand) runForElection(candidate *leadership.Candidate) {
 func (a *AgentCommand) leaderMember() (*serf.Member, error) {
 	leaderName := a.store.GetLeader()
 	for _, member := range a.serf.Members() {
-		if member.Name == leaderName {
+		if member.Name == string(leaderName) {
 			return &member, nil
 		}
 	}

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -146,7 +146,7 @@ func TestAgentCommand_runForElection(t *testing.T) {
 	shutdownCh <- struct{}{}
 
 	// Wait until test2 steps as leader
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	kv, _ = client.Get("dkron/leader")
 	leader = string(kv.Value)

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -1,6 +1,7 @@
 package dkron
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -67,7 +68,12 @@ func TestAgentCommand_runForElection(t *testing.T) {
 		ShutdownCh: shutdownCh,
 	}
 
-	s := NewStore("etcd", []string{"127.0.0.1:2379"}, nil, "dkron")
+	etcdAddr := os.Getenv("ETCD_ADDR")
+	if etcdAddr == "" {
+		etcdAddr = "127.0.0.1:2379"
+	}
+	println(etcdAddr)
+	s := NewStore("etcd", []string{etcdAddr}, nil, "dkron")
 	err := s.Client.DeleteTree("dkron")
 	if err != nil {
 		if err == store.ErrNotReachable {

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -1,7 +1,6 @@
 package dkron
 
 import (
-	"bytes"
 	"testing"
 	"time"
 

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -68,11 +68,10 @@ func TestAgentCommand_runForElection(t *testing.T) {
 		ShutdownCh: shutdownCh,
 	}
 
-	etcdAddr := os.Getenv("ETCD_ADDR")
+	etcdAddr := os.Getenv("DKRON_BACKEND_MACHINE")
 	if etcdAddr == "" {
 		etcdAddr = "127.0.0.1:2379"
 	}
-	println(etcdAddr)
 	s := NewStore("etcd", []string{etcdAddr}, nil, "dkron")
 	err := s.Client.DeleteTree("dkron")
 	if err != nil {

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -166,7 +166,7 @@ func (a *AgentCommand) jobCreateOrUpdateHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	a.schedulerRestartQuery(a.store.GetLeader())
+	a.schedulerRestartQuery(string(a.store.GetLeader()))
 
 	if err := printJson(w, r, job); err != nil {
 		log.Fatal(err)

--- a/dkron/scheduler.go
+++ b/dkron/scheduler.go
@@ -11,6 +11,7 @@ import (
 )
 
 var cronInspect = expvar.NewMap("cron_entries")
+var schedulerStarted = expvar.NewString("scheduler_started")
 
 type Scheduler struct {
 	Cron    *cron.Cron
@@ -19,6 +20,7 @@ type Scheduler struct {
 
 func NewScheduler() *Scheduler {
 	c := cron.New()
+	schedulerStarted.Set("false")
 	return &Scheduler{Cron: c, Started: false}
 }
 
@@ -33,6 +35,7 @@ func (s *Scheduler) Start(jobs []*Job) {
 	}
 	s.Cron.Start()
 	s.Started = true
+	schedulerStarted.Set("true")
 }
 
 func (s *Scheduler) Restart(jobs []*Job) {

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -253,7 +253,7 @@ func (s *Store) GetLeader() []byte {
 		return nil
 	}
 
-	log.WithField("node", res.Value).Debug("store: Retrieved leader from datastore")
+	log.WithField("node", string(res.Value)).Debug("store: Retrieved leader from datastore")
 
 	return res.Value
 }

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -241,8 +241,9 @@ func (s *Store) DeleteExecutions(jobName string) error {
 	return s.Client.DeleteTree(fmt.Sprintf("%s/executions/%s", s.keyspace, jobName))
 }
 
-func (s *Store) GetLeader() *Leader {
-	res, err := s.Client.Get(s.keyspace + "/leader")
+// Retrieve the leeader from the store
+func (s *Store) GetLeader() []byte {
+	res, err := s.Client.Get(s.LeaderKey())
 	if err != nil {
 		if err == store.ErrNotReachable {
 			log.Fatal("store: Store not reachable, be sure you have an existing key-value store running is running and is reachable.")
@@ -252,32 +253,12 @@ func (s *Store) GetLeader() *Leader {
 		return nil
 	}
 
-	log.WithFields(logrus.Fields{
-		"key": string(res.Value),
-	}).Debug("store: Retrieved leader from datastore")
+	log.WithField("node", res.Value).Debug("store: Retrieved leader from datastore")
 
-	return &Leader{Key: res.Value, LastIndex: res.LastIndex}
+	return res.Value
 }
 
-func (s *Store) TryLeaderSwap(newKey string, old *Leader) (bool, error) {
-	oldKV := &store.KVPair{
-		LastIndex: old.LastIndex,
-	}
-	success, _, err := s.Client.AtomicPut(s.keyspace+"/leader", []byte(newKey), oldKV, nil)
-
-	log.WithFields(logrus.Fields{
-		"old_leader": string(old.Key),
-		"new_leader": newKey,
-	}).Debug("store: Leader Swap")
-
-	return success, err
-}
-
-func (s *Store) SetLeader(leader string) error {
-	err := s.Client.Put(s.keyspace+"/leader", []byte(leader), nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
+// Retrieve the leader key used in the KV store to store the leader node
+func (s *Store) LeaderKey() string {
+	return s.keyspace + "/leader"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,5 @@ dkron:
     - ./:/gopath/src/github.com/victorcoder/dkron
   environment:
     - GODEBUG=netdns=go
-    - ETCD_ADDR=etcd:4001
+    - DKRON_BACKEND_MACHINE=etcd:4001
   command: go run main.go agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron_seed:8946 -debug=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,4 +39,5 @@ dkron:
     - ./:/gopath/src/github.com/victorcoder/dkron
   environment:
     - GODEBUG=netdns=go
+    - ETCD_ADDR=etcd:4001
   command: go run main.go agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron_seed:8946 -debug=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ dkron_seed:
     - ./:/gopath/src/github.com/victorcoder/dkron
   environment:
     - GODEBUG=netdns=go
-  command: go run main.go agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron:8946
+  command: go run main.go agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron:8946 -debug=true
 
 dkron:
   links:
@@ -39,4 +39,4 @@ dkron:
     - ./:/gopath/src/github.com/victorcoder/dkron
   environment:
     - GODEBUG=netdns=go
-  command: go run main.go agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron_seed:8946
+  command: go run main.go agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron_seed:8946 -debug=true

--- a/glide.lock
+++ b/glide.lock
@@ -1,72 +1,22 @@
-hash: a047b1ca118eceb0ec5f087e14c85a065be9ba3875781aad594f7a5ccf8889e0
-updated: 2016-02-22T23:08:19.361203838+01:00
+hash: e90812435137247f791d18fa44ab016383da36a837e2dea6c28bef44a0075fc1
+updated: 2016-03-02T12:52:28.449637815+01:00
 imports:
-- name: bitbucket.org/ww/goautoneg
-  version: 75cd24fc2f2c
-- name: github.com/agtorre/gocolorize
-  version: f42b554bf7f006936130c9bb4f971afd2d87f671
 - name: github.com/armon/circbuf
   version: f092b4f207b6e5cce0569056fba9e1a2735cb6cf
-- name: github.com/armon/consul-api
-  version: dcfedd50ed5334f96adee43fc88518a4f095e15c
 - name: github.com/armon/go-metrics
   version: a54701ebec11868993bc198c3f315353e9de2ed6
-- name: github.com/armon/go-radix
-  version: fbd82e84e2b13651f3abc5ffd26b65ba71bc8f93
-- name: github.com/armon/gomdb
-  version: 151f2e08ef45cb0e57d694b2562f351955dff572
-- name: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
-- name: github.com/bgentry/speakeasy
-  version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
-- name: github.com/boltdb/bolt
-  version: 90fef389f98027ca55594edd7dbd6e7f3926fdad
-- name: github.com/bradfitz/gomemcache
-  version: 72a68649ba712ee7c4b5b4a943a626bcd7d90eb8
-- name: github.com/bradfitz/http2
-  version: 3e36af6d3af0e56fa3da71099f864933dea3d9fb
-- name: github.com/bugsnag/bugsnag-go
-  version: 02e952891c52fbcb15f113d90633897355783b6e
-- name: github.com/bugsnag/osext
-  version: 0dd3f918b21bec95ace9dc86c7e70266cfc5c702
-- name: github.com/bugsnag/panicwrap
-  version: e5f9854865b9778a45169fc249e99e338d4d6f27
 - name: github.com/BurntSushi/toml
   version: 2ceedfee35ad3848e49308ab0c9a4f640cfb5fb2
-- name: github.com/carbocation/handlers
-  version: c939c6d9ef31c3d483da9db462b6fd806044ac87
 - name: github.com/carbocation/interpose
   version: 50c09d12f8624ab10532f931cb630d0bf5f7c2c7
-- name: github.com/cheggaaa/pb
-  version: da1f27ad1d9509b16f65f52fd9d8138b0f2dc7b2
-- name: github.com/codegangsta/cli
-  version: f7ebb761e83e21225d1d8954fde853bf8edd46c4
-- name: github.com/codegangsta/inject
-  version: 33e0aa1cb7c019ccc3fbe049a8262a6403d30504
-- name: github.com/codegangsta/negroni
-  version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
 - name: github.com/coreos/etcd
   version: 56b75844186dbf1464c679829787b935c0ba73ec
   subpackages:
   - client
   - pkg/pathutil
   - pkg/types
-- name: github.com/coreos/go-etcd
-  version: 003851be7bb0694fe3cc457a49529a19388ee7cf
-- name: github.com/coreos/go-semver
-  version: 568e959cd89871e61434c1143528d9162da89ef2
-  subpackages:
-  - semver
-- name: github.com/coreos/go-systemd
-  version: cea488b4e6855fee89b6c22a811e3c5baca861b6
-  subpackages:
-  - daemon
-  - journal
-  - util
-- name: github.com/coreos/pkg
-  version: 42a8c3b1a6f917bb8346ef738f32712a7ca0ede7
-  subpackages:
-  - capnslog
+  - Godeps/_workspace/src/github.com/ugorji/go/codec
+  - Godeps/_workspace/src/golang.org/x/net/context
 - name: github.com/docker/libkv
   version: c2aac5dbbaa5c872211edea7c0f32b3bd67e7410
   subpackages:
@@ -74,28 +24,6 @@ imports:
   - store/consul
   - store/etcd
   - store/zookeeper
-- name: github.com/garyburd/redigo
-  version: 6ece6e0a09f28cc399b21550cbf37ab39ba63cce
-- name: github.com/getsentry/raven-go
-  version: 3966f3ab8333308d76b6cc83a29776a266bbdd92
-- name: github.com/go-martini/martini
-  version: 15a47622d6a9b3e6a1eaca2681e4850f612471ea
-- name: github.com/godbus/dbus
-  version: 881625768bcd4ca46046c618551413fa51e07a0d
-- name: github.com/gogo/protobuf
-  version: 64f27bf06efee53589314a6e5a4af34cdd85adf6
-  subpackages:
-  - proto
-- name: github.com/goji/param
-  version: da86c81e3e3c23b1948bc7a003d381250a032aa7
-- name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
-- name: github.com/golang/protobuf
-  version: 5677a0e3d5e89854c9974e1256839ee23f8233ca
-- name: github.com/goods/httpbuf
-  version: 5709e9bb814c932e48b6737e1cf214a6522453a2
-- name: github.com/google/btree
-  version: cc6329d4279e3f025a53a83c397d2339b5705c45
 - name: github.com/gorilla/context
   version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
 - name: github.com/gorilla/mux
@@ -104,109 +32,35 @@ imports:
   version: 4adc0b5c660919e3f21c9a60f567fd872b9e3d1e
   subpackages:
   - api
-- name: github.com/hashicorp/consul-migrate
-  version: 678fb10cdeae25ab309e99e655148f0bf65f9710
-- name: github.com/hashicorp/errwrap
-  version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
-- name: github.com/hashicorp/go-checkpoint
-  version: e4b2dc34c0f698ee04750bf2035d8b9384233e1b
-- name: github.com/hashicorp/go-cleanhttp
-  version: 5df5ddc69534f1a4697289f1dca2193fbb40213f
 - name: github.com/hashicorp/go-msgpack
   version: 71c2886f5a673a35f909803f38ece5810165097b
   subpackages:
   - codec
-- name: github.com/hashicorp/go-multierror
-  version: d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5
-- name: github.com/hashicorp/go-syslog
-  version: 42a2b573b664dbf281bd48c3cc12c086b17a39ba
-- name: github.com/hashicorp/go.net
-  version: 104dcad90073cd8d1e6828b2af19185b60cf3e29
-- name: github.com/hashicorp/golang-lru
-  version: b361c4c189a958f7d0ad435952611c140751afe2
-- name: github.com/hashicorp/hcl
-  version: c40ec20b1285f01e9e75ec39f2bf2cff132891d3
-- name: github.com/hashicorp/logutils
-  version: 0dc08b1671f34c4250ce212759ebd880f743d883
-- name: github.com/hashicorp/mdns
-  version: 9d85cf22f9f8d53cb5c81c1b2749f438b2ee333f
 - name: github.com/hashicorp/memberlist
   version: 6025015f2dc659ca2c735112d37e753bda6e329d
-- name: github.com/hashicorp/net-rpc-msgpackrpc
-  version: a14192a58a694c123d8fe5481d4a4727d6ae82f3
-- name: github.com/hashicorp/raft
-  version: d136cd15dfb7876fd7c89cad1995bc4f19ceb294
-- name: github.com/hashicorp/raft-boltdb
-  version: d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee
-- name: github.com/hashicorp/raft-mdb
-  version: 55f29473b9e604b3678b93a8433a6cf089e70f76
-- name: github.com/hashicorp/scada-client
-  version: 84989fd23ad4cc0e7ad44d6a871fd793eb9beb0a
 - name: github.com/hashicorp/serf
   version: 558a6876882b2c5c61df29fd3990fb1765fd71d3
   subpackages:
   - serf
   - testutil
-- name: github.com/hashicorp/yamux
-  version: df949784da9ed028ee76df44652e42d37a09d7e4
-- name: github.com/hoisie/web
-  version: 5a66d0fa07a54688eba8fa506576a78a942ef243
-- name: github.com/inconshreveable/muxado
-  version: f693c7e88ba316d1a0ae3e205e22a01aa3ec2848
-- name: github.com/jonboulle/clockwork
-  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/jordan-wright/email
   version: 065af43fce517847a750d01a6d389d1a37e011b3
-- name: github.com/julienschmidt/httprouter
-  version: f30ab90cccbd5171771d26b6557d3c2f49e047a6
-- name: github.com/justinas/nosurf
-  version: 677db2686224c1f00a942238adf376fa5c4635cd
 - name: github.com/kr/pretty
   version: 088c856450c08c03eb32f7a6c221e6eefaa10e6f
-- name: github.com/kr/pty
-  version: f7ee69f31298ecbe5d2b349c711e2547a617d398
 - name: github.com/kr/text
   version: 6807e777504f54ad073ecef66747de158294b639
 - name: github.com/magiconair/properties
   version: d5929c67198951106f49f7ea425198d0f1a08f7f
-- name: github.com/martini-contrib/auth
-  version: fa62c19b7ae87da370242054c8beb11af31d327f
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
-- name: github.com/meatballhat/negroni-logrus
-  version: 0456e765fdc169ebcb064ac33ed462b632bfc41f
-- name: github.com/miekg/dns
-  version: 75e6e86cc601825c5dbcd4e0c209eab180997cd7
 - name: github.com/mitchellh/cli
   version: 6cc8bc522243675a2882b81662b0b0d2e04b99c9
 - name: github.com/mitchellh/mapstructure
   version: 740c764bc6149d3f1806231418adb9f52c11bcbf
-- name: github.com/phyber/negroni-gzip
-  version: 1211b7a0892223f5b3f1af8629ea6c3d9f984028
-- name: github.com/prometheus/client_golang
-  version: e51041b3fa41cece0dca035740ba6411905be473
-- name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-- name: github.com/prometheus/common
-  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
-- name: github.com/prometheus/procfs
-  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
-- name: github.com/revel/revel
-  version: a9a2ff45fae4330ef4116b257bcf9c82e53350c2
-- name: github.com/robfig/config
-  version: 0f78529c8c7e3e9a25f15876532ecbc07c7d99e6
-- name: github.com/robfig/go-cache
-  version: 9fc39e0dbf62c034ec4e45e6120fc69433a3ec51
-- name: github.com/robfig/pathtree
-  version: 41257a1839e945fce74afd070e02bab2ea2c776a
-- name: github.com/ryanuber/columnize
-  version: 983d3a5fab1bf04d1b412465d2d9f8430e2e917e
 - name: github.com/samuel/go-zookeeper
   version: 177002e16a0061912f02377e2dd8951a8b3551bc
   subpackages:
   - zk
 - name: github.com/Sirupsen/logrus
-  version: 52919f182f9c314f8a38c5afe96506f73d02b4b2
+  version: be52937128b38f1d99787bb476c789e2af1147f1
 - name: github.com/spf13/cast
   version: ee815aaf958c707ad07547cd62150d973710f747
 - name: github.com/spf13/jwalterweatherman
@@ -215,30 +69,10 @@ imports:
   version: 463bdc838f2b35e9307e91d480878bda5fff7232
 - name: github.com/spf13/viper
   version: 2abb1bebfde865b0bb6bb7ada5be63ec78527fa6
-- name: github.com/stretchr/graceful
-  version: 48afeb21e2fcbcff0f30bd5ad6b97747b0fae38e
-- name: github.com/stretchr/objx
-  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
-- name: github.com/stretchr/testify
-  version: 9cc77fa25329013ce07362c7742952ff887361f2
-  subpackages:
-  - assert
-- name: github.com/tobi/airbrake-go
-  version: a3cdd910a3ffef88a20fbecc10363a520ad61a0a
-- name: github.com/tylerb/graceful
-  version: 48afeb21e2fcbcff0f30bd5ad6b97747b0fae38e
 - name: github.com/ugorji/go
   version: 8a2a3a8c488c3ebd98f422a965260278267a0551
   subpackages:
   - codec
-- name: github.com/unrolled/secure
-  version: 9b725bb5ee80564334176a116a99dd926cab63a1
-- name: github.com/xiang90/probing
-  version: 6a0cc1ae81b4cc11db5e491e030e4b98fba79c19
-- name: github.com/xordataexchange/crypt
-  version: 749e360c8f236773f28fc6d3ddfce4a470795227
-- name: github.com/zenazn/goji
-  version: bf843a174a08e846246b8945f8a9a853d84a256a
 - name: golang.org/x/crypto
   version: 24ffb5feb3312a39054178a4b0a4554fc2201248
   subpackages:
@@ -247,29 +81,10 @@ imports:
   version: 1dfe7915deaf3f80b962c163b918868d8a6d8974
   subpackages:
   - context
-- name: golang.org/x/oauth2
-  version: 3046bc76d6dfd7d3707f6640f85e42d9c4050f50
 - name: golang.org/x/sys
   version: 9c60d1c508f5134d1ca726b4641db998f2523357
   subpackages:
   - unix
-- name: golang.org/x/text
-  version: dd164d33a23c6e075adc2b75ac1ae939b81324aa
-- name: google.golang.org/api
-  version: ece7143efeb53ec1839b960a0849db4e57d3cfa2
-- name: google.golang.org/appengine
-  version: 7bed6a18ea6f00deda4ea0b2797f715c7c555a6c
-- name: google.golang.org/cloud
-  version: f20d6dcccb44ed49de45ae3703312cb46e627db1
-  subpackages:
-  - compute/metadata
-  - internal
-- name: google.golang.org/grpc
-  version: f5ebd86be717593ab029545492c93ddf8914832b
-- name: gopkg.in/fsnotify.v1
-  version: 2cdd39bd6129c6a49c74fb07fb9d77ba1271c572
-- name: gopkg.in/yaml.v1
-  version: 9f9df34309c04878acc86042b16630b0f696e1de
 - name: gopkg.in/yaml.v2
   version: 49c95bdc21843256fb6c4e0d370a05f24a0bf213
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e90812435137247f791d18fa44ab016383da36a837e2dea6c28bef44a0075fc1
-updated: 2016-03-02T12:52:28.449637815+01:00
+hash: e04a8202b519a27ad67af782f72fd2dc484602a3c3df0d9088ac1cd706ca8f16
+updated: 2016-03-03T12:02:24.828962696+01:00
 imports:
 - name: github.com/armon/circbuf
   version: f092b4f207b6e5cce0569056fba9e1a2735cb6cf
@@ -17,6 +17,8 @@ imports:
   - pkg/types
   - Godeps/_workspace/src/github.com/ugorji/go/codec
   - Godeps/_workspace/src/golang.org/x/net/context
+- name: github.com/docker/leadership
+  version: b545f2df5f5cd35a54c5a6bf154dcfe1f29d125b
 - name: github.com/docker/libkv
   version: c2aac5dbbaa5c872211edea7c0f32b3bd67e7410
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -80,3 +80,4 @@ import:
   - context
 - package: gopkg.in/yaml.v2
   version: 49c95bdc21843256fb6c4e0d370a05f24a0bf213
+- package: github.com/docker/leadership

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/BurntSushi/toml
   version: 2ceedfee35ad3848e49308ab0c9a4f640cfb5fb2
 - package: github.com/Sirupsen/logrus
-  version: 52919f182f9c314f8a38c5afe96506f73d02b4b2
+  version: 0.9.0
 - package: github.com/armon/circbuf
   version: f092b4f207b6e5cce0569056fba9e1a2735cb6cf
 - package: github.com/armon/go-metrics


### PR DESCRIPTION
After some tests, I detected an edge case where a leader can be disconected from the cluster and still retain the scheduler started, never stopping to execute jobs even when there are a new leader with the scheduler running.

This is due to how serf work and the method dkron was using to detect node failures and leader election.

Now using `leadership` ensures the leader election is always reliable and no duplicate scheduler instances are running at the same time in the cluster.

Also a lot of custom code deletion it's a big win.