### PR TITLE
Change debug param for log-level

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -98,7 +98,7 @@ Options:
   -webhook-payload                Body of the POST request to send on webhook call.
   -webhook-header                 Headers to use when calling the webhook URL. Can be specified multiple times.
 
-  -debug=false                    Output debug log
+  -log-level=info                 Log level (debug, info, warn, error, fatal, panic). Default to info.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -136,7 +136,10 @@ func (a *AgentCommand) readConfig(args []string) *Config {
 	viper.SetDefault("keyspace", cmdFlags.Lookup("keyspace").Value)
 	cmdFlags.String("encrypt", "", "encryption key")
 	viper.SetDefault("encrypt", cmdFlags.Lookup("encrypt").Value)
-	viper.SetDefault("debug", cmdFlags.Bool("debug", false, "output debug log"))
+
+	cmdFlags.String("log-level", "info", "Log level (debug, info, warn, error, fatal, panic), defaults to info")
+	viper.SetDefault("log_level", cmdFlags.Lookup("log-level").Value)
+
 	cmdFlags.String("ui-dir", ".", "directory to serve web UI")
 	viper.SetDefault("ui_dir", cmdFlags.Lookup("ui-dir").Value)
 	viper.SetDefault("rpc_port", cmdFlags.Int("rpc-port", 6868, "RPC port"))
@@ -180,7 +183,7 @@ func (a *AgentCommand) readConfig(args []string) *Config {
 		tags["server"] = "true"
 	}
 
-	SetLogLevel(viper.GetBool("debug"))
+	InitLogger(viper.GetString("log_level"), nodeName)
 
 	return &Config{
 		NodeName:        nodeName,

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/hashicorp/serf/testutil"
@@ -27,8 +26,6 @@ func TestAgentCommand_implements(t *testing.T) {
 }
 
 func TestAgentCommandRun(t *testing.T) {
-	log.Level = logrus.FatalLevel
-
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)
 
@@ -99,7 +96,7 @@ func TestAgentCommand_runForElection(t *testing.T) {
 		"-join", a2Addr,
 		"-node", a1Name,
 		"-server",
-		"-debug",
+		"-log-level", "debug",
 	}
 
 	resultCh := make(chan int)
@@ -127,7 +124,7 @@ func TestAgentCommand_runForElection(t *testing.T) {
 		"-join", a1Addr + ":8946",
 		"-node", a2Name,
 		"-server",
-		"-debug",
+		"-log-level", "debug",
 	}
 
 	resultCh2 := make(chan int)
@@ -157,8 +154,6 @@ func TestAgentCommand_runForElection(t *testing.T) {
 }
 
 func Test_processFilteredNodes(t *testing.T) {
-	log.Level = logrus.ErrorLevel
-
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)
 
@@ -264,8 +259,6 @@ func Test_UnmarshalTags(t *testing.T) {
 }
 
 func TestEncrypt(t *testing.T) {
-	log.Level = logrus.ErrorLevel
-
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)
 

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -7,14 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/hashicorp/serf/testutil"
 	"github.com/mitchellh/cli"
 )
 
 func setupAPITest(t *testing.T) (chan<- struct{}, <-chan int) {
-	log.Level = logrus.FatalLevel
-
 	shutdownCh := make(chan struct{})
 	// defer close(shutdownCh)
 

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -55,7 +56,7 @@ func init() {
 	viper.AddConfigPath("./config")     // call multiple times to add many search paths
 	err := viper.ReadInConfig()         // Find and read the config file
 	if err != nil {                     // Handle errors reading the config file
-		log.Infof("No valid config found: %s \n Applying default values.", err)
+		logrus.Infof("No valid config found: %s \n Applying default values.", err)
 	}
 
 	viper.SetEnvPrefix("dkron") // will be uppercased automatically

--- a/dkron/log.go
+++ b/dkron/log.go
@@ -4,16 +4,19 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
-var log = logrus.New()
+var log *logrus.Entry
 
-func init() {
-	log.Formatter = &logrus.TextFormatter{FullTimestamp: true}
-}
+func InitLogger(logLevel string, node string) {
+	formattedLogger := logrus.New()
+	formattedLogger.Formatter = &logrus.TextFormatter{FullTimestamp: true}
 
-func SetLogLevel(debug bool) {
-	if debug {
-		log.Level = logrus.DebugLevel
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		logrus.WithError(err).Error("Error parsing log level, using: info")
 	} else {
-		log.Level = logrus.InfoLevel
+		level = logrus.InfoLevel
 	}
+
+	formattedLogger.Level = level
+	log = logrus.NewEntry(formattedLogger).WithField("node", node)
 }

--- a/dkron/scheduler_test.go
+++ b/dkron/scheduler_test.go
@@ -2,8 +2,6 @@ package dkron
 
 import (
 	"testing"
-
-	"github.com/Sirupsen/logrus"
 )
 
 func testJobs() []*Job {
@@ -18,8 +16,6 @@ func testJobs() []*Job {
 }
 
 func TestSchedule(t *testing.T) {
-	log.Level = logrus.FatalLevel
-
 	sched := NewScheduler()
 
 	if sched.Started == true {

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -38,7 +38,7 @@ Settings for dkron can be specified in three ways: Using a `config/dkron.json` c
 
 * `-webhook-header` - Headers to use when calling the webhook URL. Can be specified multiple times.
 
-* `-debug` - Output debug info.
+* `-log-level` - Set the log level (debug, info, warn, error, fatal, panic). Defaults to "info"
 
 * `-ui-dir` - Directory from where to serve web UI.
 


### PR DESCRIPTION
The logger now is configured to report the node on every log entry.

A new param log-level offers more control on the granularity of log
verbosity.