### PR TITLE
Shellwords

### DIFF
--- a/dkron/proc.go
+++ b/dkron/proc.go
@@ -3,7 +3,6 @@ package dkron
 import (
 	"math/rand"
 	"os/exec"
-	"runtime"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -31,7 +30,7 @@ func (a *AgentCommand) invokeJob(execution *Execution) error {
 	if err != nil {
 		log.WithError(err).Fatal("proc: Error parsing command arguments")
 	}
-	cmd := exec.Command(args)
+	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stderr = output
 	cmd.Stdout = output
 
@@ -50,7 +49,7 @@ func (a *AgentCommand) invokeJob(execution *Execution) error {
 	}
 
 	var success bool
-	err := cmd.Wait()
+	err = cmd.Wait()
 	slowTimer.Stop()
 	log.WithFields(logrus.Fields{
 		"output": output,

--- a/dkron/proc.go
+++ b/dkron/proc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/serf/serf"
+	"github.com/mattn/go-shellwords"
 )
 
 const (
@@ -26,17 +27,11 @@ func (a *AgentCommand) invokeJob(execution *Execution) error {
 
 	output, _ := circbuf.NewBuffer(maxBufSize)
 
-	// Determine the shell invocation based on OS
-	var shell, flag string
-	if runtime.GOOS == windows {
-		shell = "cmd"
-		flag = "/C"
-	} else {
-		shell = "/bin/sh"
-		flag = "-c"
+	args, err := shellwords.Parse(job.Command)
+	if err != nil {
+		log.WithError(err).Fatal("proc: Error parsing command arguments")
 	}
-
-	cmd := exec.Command(shell, flag, job.Command)
+	cmd := exec.Command(args)
 	cmd.Stderr = output
 	cmd.Stdout = output
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c8a98133409aacd60189b994e021166a4c60cb4cfaba2679f635fac68f4b25b9
-updated: 2016-04-30T00:34:30.779633055+02:00
+hash: 36a479508b0306ce919b2a6d4eb99df98b36f9eb14202c3a08c85246ca19e9fe
+updated: 2016-05-03T17:32:15.075162169+02:00
 imports:
 - name: github.com/armon/circbuf
   version: f092b4f207b6e5cce0569056fba9e1a2735cb6cf
@@ -55,6 +55,8 @@ imports:
   version: 6807e777504f54ad073ecef66747de158294b639
 - name: github.com/magiconair/properties
   version: d5929c67198951106f49f7ea425198d0f1a08f7f
+- name: github.com/mattn/go-shellwords
+  version: 525bedee691b5a8df547cb5cf9f86b7fb1883e24
 - name: github.com/mitchellh/cli
   version: 6cc8bc522243675a2882b81662b0b0d2e04b99c9
 - name: github.com/mitchellh/mapstructure

--- a/glide.yaml
+++ b/glide.yaml
@@ -83,3 +83,4 @@ import:
 - package: github.com/docker/leadership
 - package: github.com/imdario/mergo
 - package: github.com/stretchr/testify
+- package: github.com/mattn/go-shellwords

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 docker-compose up -d etcd
-export COMPOSE_ETCD_PORT=`docker port dockercompose_etcd_1 4001/tcp | cut -d":" -f 2`
+export COMPOSE_ETCD_PORT=`docker port dkron_etcd_1 4001/tcp | cut -d":" -f 2`
 export DKRON_BACKEND_MACHINE=`docker-machine ip default`:$COMPOSE_ETCD_PORT
 go test -v ./dkron $1


### PR DESCRIPTION
Use `go-shellwords` to parse the command to execute and get rid of the shell call.

Fixes #97 