### PR TITLE
Replace server tag for dkron_server and add dkron_version

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -183,7 +183,8 @@ func (a *AgentCommand) readConfig(args []string) *Config {
 	nodeName := viper.GetString("node_name")
 
 	if server {
-		tags["server"] = "true"
+		tags["dkron_server"] = "true"
+		tags["dkron_version"] = a.Version
 	}
 
 	InitLogger(viper.GetString("log_level"), nodeName)
@@ -533,7 +534,7 @@ func (a *AgentCommand) listServers() []serf.Member {
 	members := []serf.Member{}
 
 	for _, member := range a.serf.Members() {
-		if key, ok := member.Tags["server"]; ok {
+		if key, ok := member.Tags["dkron_server"]; ok {
 			if key == "true" && member.Status == serf.StatusAlive {
 				members = append(members, member)
 			}

--- a/dkron/proc.go
+++ b/dkron/proc.go
@@ -88,7 +88,7 @@ func (a *AgentCommand) queryRPCConfig() ([]byte, error) {
 
 	params := &serf.QueryParam{
 		FilterNodes: []string{nodeName},
-		FilterTags:  map[string]string{"server": "true"},
+		FilterTags:  map[string]string{"dkron_server": "true"},
 		RequestAck:  true,
 	}
 


### PR DESCRIPTION
The server tag is to generic and must not be used by dkron also it's
good to know the version running in each host.