### PR TITLE
Fix simple scheduling

### DIFF
--- a/cron/simple.go
+++ b/cron/simple.go
@@ -1,6 +1,8 @@
 package cron
 
-import "time"
+import (
+	"time"
+)
 
 // SimpleDelaySchedule represents a simple non recurring duration.
 type SimpleSchedule struct {
@@ -17,5 +19,11 @@ func At(date time.Time) SimpleSchedule {
 // Next conforms to the Schedule interface but this kind of jobs
 // doesn't need to be run more than once, so it doesn't return a new date but the existing one.
 func (schedule SimpleSchedule) Next(t time.Time) time.Time {
-	return schedule.Date
+	// If the date set is after the reference time return it
+	// if it's before, return a virtually infinite sleep date
+	// so do nothing.
+	if schedule.Date.After(t) {
+		return schedule.Date
+	}
+	return t.AddDate(10, 0, 0)
 }

--- a/cron/simple_test.go
+++ b/cron/simple_test.go
@@ -1,0 +1,33 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSimpleNext(t *testing.T) {
+	tests := []struct {
+		time     string
+		date     string
+		expected string
+	}{
+		// Simple cases
+		{"2012-07-09T14:45:00Z", "2012-07-09T15:00:00Z", "2012-07-09T15:00:00Z"},
+		{"2012-07-09T14:45:00Z", "2012-07-05T13:00:00Z", "2022-07-09T14:45:00Z"},
+	}
+
+	for _, c := range tests {
+		now, _ := time.Parse(time.RFC3339, c.time)
+		date, _ := time.Parse(time.RFC3339, c.date)
+		actual := At(date).Next(now)
+		expected, _ := time.Parse(time.RFC3339, c.expected)
+
+		if !actual.After(now) {
+			t.Errorf("%s, \"%s\": (expected) %v after %v (actual)", c.time, c.date, expected, actual)
+		}
+
+		if actual != expected {
+			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.date, expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
The simple schedule must return a virtually ahead time when the schedule is passed the reference time.