### PR TITLE
Support for arbitrary job size

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -495,11 +495,11 @@ func (a *AgentCommand) eventLoop() {
 					if err != nil {
 						log.WithError(err).Error("agent: Error on rpc.GetJob call")
 					}
+					log.WithField("command", job.Command).Debug("agent: GetJob by RPC")
 
-					ex := &Execution{
-						StartedAt: time.Now(),
-						NodeName:  a.config.NodeName,
-					}
+					ex := rqp.Execution
+					ex.StartedAt = time.Now()
+					ex.NodeName = a.config.NodeName
 
 					go func() {
 						if err := a.invokeJob(job, ex); err != nil {

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -487,30 +487,26 @@ func (a *AgentCommand) eventLoop() {
 					}
 
 					log.WithFields(logrus.Fields{
-						"job": rqp.JobName,
+						"job": rqp.Execution.JobName,
 					}).Info("agent: Starting job")
 
 					rpcc := RPCClient{ServerAddr: rqp.RPCAddr}
-					job, err := rpcc.GetJob(rqp.JobName)
+					job, err := rpcc.GetJob(rqp.Execution.JobName)
 					if err != nil {
 						log.WithError(err).Error("agent: Error on rpc.GetJob call")
 					}
 
 					ex := &Execution{
 						StartedAt: time.Now(),
-						Success:   false,
 						NodeName:  a.config.NodeName,
-						Job:       job,
 					}
 
 					go func() {
-						if err := a.invokeJob(ex); err != nil {
+						if err := a.invokeJob(job, ex); err != nil {
 							log.WithError(err).Error("agent: Error invoking job command")
 						}
 					}()
 
-					// Unset the job in execution before sending the response
-					ex.Job = nil
 					exJson, _ := json.Marshal(ex)
 					query.Respond(exJson)
 				}

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -17,10 +17,6 @@ import (
 	"github.com/hashicorp/serf/serf"
 )
 
-var (
-	ErrOversizedJob = errors.New(fmt.Sprintf("Due to serf limitations in message size, the job has a maximum size of %d", serf.UserEventSizeLimit))
-)
-
 func (a *AgentCommand) ServeHTTP() {
 	r := mux.NewRouter().StrictSlash(true)
 

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -2,7 +2,6 @@ package dkron
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +13,6 @@ import (
 	"github.com/carbocation/interpose"
 	"github.com/docker/libkv/store"
 	"github.com/gorilla/mux"
-	"github.com/hashicorp/serf/serf"
 )
 
 func (a *AgentCommand) ServeHTTP() {

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -157,14 +157,6 @@ func (a *AgentCommand) jobCreateOrUpdateHandler(w http.ResponseWriter, r *http.R
 		log.Fatal(err)
 	}
 
-	if len(body) >= serf.UserEventSizeLimit {
-		w.WriteHeader(422) // unprocessable entity
-		if err := json.NewEncoder(w).Encode(ErrOversizedJob.Error()); err != nil {
-			log.Fatal(err)
-		}
-		return
-	}
-
 	if err := json.Unmarshal(body, &job); err != nil {
 		w.WriteHeader(422) // unprocessable entity
 		if err := json.NewEncoder(w).Encode(err); err != nil {

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -236,7 +236,9 @@ func (a *AgentCommand) jobRunHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	a.RunQuery(job)
+
+	ex := NewExecution(job.Name)
+	a.RunQuery(ex)
 
 	if err := printJson(w, r, job); err != nil {
 		log.Fatal(err)

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/carbocation/interpose"
@@ -251,15 +250,7 @@ func (a *AgentCommand) jobRunHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-
-	ex := &Execution{
-		JobName: job.Name,
-		Group:   time.Now().UnixNano(),
-		Job:     job,
-		Attempt: 1,
-	}
-
-	a.RunQuery(ex)
+	a.RunQuery(job)
 
 	if err := printJson(w, r, job); err != nil {
 		log.Fatal(err)

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -85,30 +85,6 @@ func TestAPIJobCreateUpdate(t *testing.T) {
 	shutdownCh <- struct{}{}
 }
 
-func TestAPIJobCreateUpdateLength(t *testing.T) {
-	shutdownCh, _ := setupAPITest(t)
-
-	rb := make([]byte, 1024)
-	rand.Read(rb)
-	rs := base64.URLEncoding.EncodeToString(rb)
-
-	jsonStr := []byte(fmt.Sprintf("{\"name\": \"test_job\", \"command\": \"%s\"}", rs))
-
-	resp, err := http.Post("http://localhost:8090/v1/jobs", "encoding/json", bytes.NewBuffer(jsonStr))
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, _ := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-
-	assert.Equal(t, 422, resp.StatusCode)
-	errJson, err := json.Marshal(ErrOversizedJob.Error())
-	assert.Equal(t, string(errJson)+"\n", string(body))
-
-	// Send a shutdown request
-	shutdownCh <- struct{}{}
-}
-
 func TestAPIJobCreateUpdateParentJob_SameParent(t *testing.T) {
 	shutdownCh, _ := setupAPITest(t)
 

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -2,11 +2,8 @@ package dkron
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"testing"
 	"time"

--- a/dkron/execution.go
+++ b/dkron/execution.go
@@ -29,9 +29,15 @@ type Execution struct {
 
 	// Retry attempt of this execution.
 	Attempt uint `json:"attempt,omitempty"`
+}
 
-	// The job used to generate this execution.
-	Job *Job `json:"job,omitempty"`
+// Init a new execution
+func NewExecution(jobName string) *Execution {
+	return &Execution{
+		JobName: jobName,
+		Group:   time.Now().UnixNano(),
+		Attempt: 1,
+	}
 }
 
 // Used to enerate the execution Id

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -95,7 +95,10 @@ func (j *Job) Run() {
 		}).Debug("scheduler: Run job")
 
 		cronInspect.Set(j.Name, j)
-		j.Agent.RunQuery(j)
+
+		// Simple execution wrapper
+		ex := NewExecution(j.Name)
+		j.Agent.RunQuery(ex)
 	}
 }
 

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -94,15 +94,8 @@ func (j *Job) Run() {
 			"schedule": j.Schedule,
 		}).Debug("scheduler: Run job")
 
-		ex := &Execution{
-			JobName: j.Name,
-			Group:   time.Now().UnixNano(),
-			Job:     j,
-			Attempt: 1,
-		}
-
 		cronInspect.Set(j.Name, j)
-		j.Agent.RunQuery(ex)
+		j.Agent.RunQuery(j)
 	}
 }
 

--- a/dkron/notifier.go
+++ b/dkron/notifier.go
@@ -16,20 +16,22 @@ import (
 
 type Notifier struct {
 	Config         *Config
+	Job            *Job
 	Execution      *Execution
 	ExecutionGroup []*Execution
 }
 
-func Notification(config *Config, execution *Execution, exGroup []*Execution) *Notifier {
+func Notification(config *Config, execution *Execution, exGroup []*Execution, job *Job) *Notifier {
 	return &Notifier{
 		Config:         config,
 		Execution:      execution,
 		ExecutionGroup: exGroup,
+		Job:            job,
 	}
 }
 
 func (n *Notifier) Send() {
-	if n.Config.MailHost != "" && n.Config.MailPort != 0 && n.Execution.Job.OwnerEmail != "" {
+	if n.Config.MailHost != "" && n.Config.MailPort != 0 && n.Job.OwnerEmail != "" {
 		n.sendExecutionEmail()
 	}
 	if n.Config.WebhookURL != "" && n.Config.WebhookPayload != "" {
@@ -62,7 +64,7 @@ func (n *Notifier) report() string {
 
 func (n *Notifier) sendExecutionEmail() {
 	e := &email.Email{
-		To:      []string{n.Execution.Job.OwnerEmail},
+		To:      []string{n.Job.OwnerEmail},
 		From:    n.Config.MailFrom,
 		Subject: fmt.Sprintf("[Dkron] %s %s execution report", n.statusString(n.Execution), n.Execution.JobName),
 		Text:    []byte(n.report()),

--- a/dkron/notifier_test.go
+++ b/dkron/notifier_test.go
@@ -20,7 +20,7 @@ func TestNotifier_callExecutionWebhook(t *testing.T) {
 		WebhookHeaders: []string{"Content-Type: application/x-www-form-urlencoded"},
 	}
 
-	n := Notification(c, &Execution{}, []*Execution{})
+	n := Notification(c, &Execution{}, []*Execution{}, &Job{})
 
 	n.Send()
 }
@@ -43,7 +43,6 @@ func TestNotifier_sendExecutionEmail(t *testing.T) {
 		StartedAt:  time.Now(),
 		FinishedAt: time.Now(),
 		Success:    true,
-		Job:        job,
 		NodeName:   "test-node",
 		Output:     []byte("test-output"),
 	}
@@ -52,14 +51,13 @@ func TestNotifier_sendExecutionEmail(t *testing.T) {
 		{
 			JobName:   "test",
 			StartedAt: time.Now(),
-			Job:       job,
 			NodeName:  "test-node2",
 			Output:    []byte("test-output"),
 		},
 		ex1,
 	}
 
-	n := Notification(c, ex1, exg)
+	n := Notification(c, ex1, exg, job)
 
 	n.Send()
 }

--- a/dkron/proc.go
+++ b/dkron/proc.go
@@ -22,8 +22,8 @@ const (
 )
 
 // invokeJob will execute the given job. Depending on the event.
-func (a *AgentCommand) invokeJob(execution *Execution) error {
-	job := execution.Job
+func (a *AgentCommand) invokeJob(job *Job, execution *Execution) error {
+	log.Fatal(job.Command, job.Shell)
 
 	output, _ := circbuf.NewBuffer(maxBufSize)
 

--- a/dkron/proc.go
+++ b/dkron/proc.go
@@ -23,8 +23,6 @@ const (
 
 // invokeJob will execute the given job. Depending on the event.
 func (a *AgentCommand) invokeJob(job *Job, execution *Execution) error {
-	log.Fatal(job.Command, job.Shell)
-
 	output, _ := circbuf.NewBuffer(maxBufSize)
 
 	cmd := buildCmd(job)

--- a/dkron/queries.go
+++ b/dkron/queries.go
@@ -2,7 +2,6 @@ package dkron
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/hashicorp/serf/serf"
@@ -15,34 +14,45 @@ const (
 )
 
 type RunQueryParam struct {
-	JobName        string `json:"job_name"`
-	ExecutionGroup int64  `json:"execution_group"`
-	RPCAddr        string `json:"rpc_addr"`
+	Execution *Execution `json:"execution"`
+	RPCAddr   string     `json:"rpc_addr"`
 }
 
 // Send a serf run query to the cluster, this is used to ask a node or nodes
 // to run a Job.
-func (a *AgentCommand) RunQuery(job *Job) {
-	filterNodes, filterTags, err := a.processFilteredNodes(job)
-	if err != nil {
-		log.WithFields(logrus.Fields{
-			"job": job.Name,
-			"err": err.Error(),
-		}).Fatal("agent: Error processing filtered nodes")
-	}
-	log.Debug("agent: Filtered nodes to run: ", filterNodes)
-	log.Debug("agent: Filtered tags to run: ", job.Tags)
+func (a *AgentCommand) RunQuery(ex *Execution) {
+	var params *serf.QueryParam
 
-	params := &serf.QueryParam{
-		FilterNodes: filterNodes,
-		FilterTags:  filterTags,
-		RequestAck:  true,
+	job, _ := a.store.GetJob(ex.JobName)
+
+	// In the first execution attempt we build and filter the target nodes
+	// but we use the existing node target in case of retry.
+	if ex.Attempt <= 1 {
+		filterNodes, filterTags, err := a.processFilteredNodes(job)
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"job": job.Name,
+				"err": err.Error(),
+			}).Fatal("agent: Error processing filtered nodes")
+		}
+		log.Debug("agent: Filtered nodes to run: ", filterNodes)
+		log.Debug("agent: Filtered tags to run: ", job.Tags)
+
+		params = &serf.QueryParam{
+			FilterNodes: filterNodes,
+			FilterTags:  filterTags,
+			RequestAck:  true,
+		}
+	} else {
+		params = &serf.QueryParam{
+			FilterNodes: []string{ex.NodeName},
+			RequestAck:  true,
+		}
 	}
 
 	rqp := &RunQueryParam{
-		JobName:        job.Name,
-		ExecutionGroup: time.Now().UnixNano(),
-		RPCAddr:        a.getRPCAddr(),
+		Execution: ex,
+		RPCAddr:   a.getRPCAddr(),
 	}
 	rqpJson, _ := json.Marshal(rqp)
 

--- a/dkron/rpc.go
+++ b/dkron/rpc.go
@@ -24,10 +24,14 @@ func (rpcs *RPCServer) GetJob(jobName string, job *Job) error {
 		"job": jobName,
 	}).Debug("rpc: Received GetJob")
 
-	job, err := rpcs.agent.store.GetJob(jobName)
+	j, err := rpcs.agent.store.GetJob(jobName)
 	if err != nil {
 		return err
 	}
+	// Copy the data structure
+	job.Shell = j.Shell
+	job.Command = j.Command
+
 	return nil
 }
 
@@ -192,7 +196,7 @@ func (rpcc *RPCClient) GetJob(jobName string) (*Job, error) {
 	defer client.Close()
 
 	// Synchronous call
-	var job *Job
+	var job Job
 	err = client.Call("RPCServer.GetJob", jobName, &job)
 	if err != nil {
 		log.WithFields(logrus.Fields{
@@ -201,5 +205,5 @@ func (rpcc *RPCClient) GetJob(jobName string) (*Job, error) {
 		return nil, err
 	}
 
-	return job, nil
+	return &job, nil
 }


### PR DESCRIPTION
We're sending a lightweight object when RunQuery is called, moving the responsibility of obtaining the full job object to the RPC system.

This allow for defining arbitrary big job objects.

Gotcha: Retries system needs a rethinking

Related to #125 and fixes #122