### PR TITLE
Add advertise_addr to example conf file in docs.

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -55,6 +55,7 @@ Settings for dkron can be specified in three ways: Using a `config/dkron.json` c
 {
   "backend": "etcd",
   "backend_machine": "127.0.0.1:2379",
+  "advertise_addr": "192.168.50.1",
   "server": false,
   "debug": false,
   "tags": {


### PR DESCRIPTION
I was wondering why my nodes weren't advertising the proper address when I specified the "advertise" option in dkron.json. I tried it on the command line and it worked. Looking at the [code](https://github.com/victorcoder/dkron/blob/master/dkron/config.go#L160) showed me the options are differently named in the command line and in the conf file and it should actually be "advertise_addr".

This should hopefully help someone else not waste a bit of time.