### PR TITLE
#184 Hotfix: Performs nil check to mitigate a panic raised as described in #184

### DIFF
--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -90,7 +90,7 @@ func TestAgentCommand_runForElection(t *testing.T) {
 	err = client.DeleteTree("dkron")
 	if err != nil {
 		if err != store.ErrKeyNotFound {
-			panic(err)
+			t.Fatal(err)
 		}
 	}
 
@@ -134,7 +134,10 @@ func TestAgentCommand_runForElection(t *testing.T) {
 		resultCh2 <- a2.Run(args2)
 	}()
 
-	kv, _ := client.Get("dkron/leader")
+	kv, err := client.Get("dkron/leader")
+	if err != nil {
+		t.Fatal(err)
+	}
 	leader := string(kv.Value)
 	log.Printf("%s is the current leader", leader)
 	if leader != a1Name {

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -240,6 +240,9 @@ func (s *Store) DeleteJob(name string) (*Job, error) {
 
 func (s *Store) GetExecutions(jobName string) ([]*Execution, error) {
 	prefix := fmt.Sprintf("%s/executions/%s", s.keyspace, jobName)
+	if s.Client == nil {
+		return nil, fmt.Errorf("Store client couldn't be found\n")
+	}
 	res, err := s.Client.List(prefix)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#184 Panic is thrown on store.go:243. It is accessing to a store.Store member of the type Store which is nil.

This fix is doing the nil checking to return an error if client is not found.

I have also take advantage of this PR to fix a panic raised in tests. It is generally not recommended and much more idiomatic to use t.Fatal in a test.