### PR TITLE
Make Travis builds work also on forked repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - 1.6
 
+# this is necessary for fork builds to work
+go_import_path: github.com/victorcoder/dkron
+
 # let us have speedy Docker-based Travis workers
 # http://docs.travis-ci.com/user/migrating-from-legacy/#tl%3Bdr
 sudo: false


### PR DESCRIPTION
Due to the Go's insistence on specific directory structure, the Travis build fails when running on forked repos. This directive makes it work for forks too.