### PR TITLE
Add template variables for additional customization of webhook and email output

### DIFF
--- a/dkron/config.go
+++ b/dkron/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	MailUsername string
 	MailPassword string
 	MailFrom     string
+	MailPayload  string
 
 	WebhookURL     string
 	WebhookPayload string
@@ -114,6 +115,8 @@ func NewConfig(args []string, agent *AgentCommand) *Config {
 	viper.SetDefault("mail_password", cmdFlags.Lookup("mail-password").Value)
 	cmdFlags.String("mail-from", "", "notification emails from address")
 	viper.SetDefault("mail_from", cmdFlags.Lookup("mail-from").Value)
+	cmdFlags.String("mail-payload", "", "notification mail payload")
+	viper.SetDefault("mail_payload", cmdFlags.Lookup("mail-payload").Value)
 
 	cmdFlags.String("webhook-url", "", "notification webhook url")
 	viper.SetDefault("webhook_url", cmdFlags.Lookup("webhook-url").Value)
@@ -176,6 +179,7 @@ func ReadConfig(agent *AgentCommand) *Config {
 		MailUsername: viper.GetString("mail_username"),
 		MailPassword: viper.GetString("mail_password"),
 		MailFrom:     viper.GetString("mail_from"),
+		MailPayload:  viper.GetString("mail_payload"),
 
 		WebhookURL:     viper.GetString("webhook_url"),
 		WebhookPayload: viper.GetString("webhook_payload"),

--- a/dkron/notifier_test.go
+++ b/dkron/notifier_test.go
@@ -1,6 +1,7 @@
 package dkron
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -60,4 +61,89 @@ func TestNotifier_sendExecutionEmail(t *testing.T) {
 	n := Notification(c, ex1, exg, job)
 
 	n.Send()
+}
+
+func TestNotifier_buildTemplate(t *testing.T) {
+	c := &Config{
+		NodeName: "test-node",
+	}
+
+	ex1 := &Execution{
+		JobName:    "test",
+		StartedAt:  time.Now(),
+		FinishedAt: time.Now(),
+		Success:    true,
+		NodeName:   "test-node",
+		Output:     []byte("test-output"),
+	}
+
+	exg := []*Execution{
+		{
+			JobName:   "test",
+			StartedAt: time.Now(),
+			NodeName:  "test-node2",
+			Output:    []byte("test-output"),
+		},
+		ex1,
+	}
+
+	n := Notification(c, ex1, exg, nil)
+	for _, tc := range templateTestCases(n) {
+		got := n.buildTemplate(tc.template).String()
+
+		if tc.exp != got {
+			t.Errorf("Exp: %s\nGot: %s", tc.exp, got)
+		}
+	}
+}
+
+type templateTestCase struct {
+	desc     string
+	exp      string
+	template string
+}
+
+var templateTestCases = func(n *Notifier) []templateTestCase {
+	return []templateTestCase{
+		{
+			desc:     "Report template variable",
+			exp:      n.report(),
+			template: "{{.Report}}",
+		},
+		{
+			desc:     "JobName template variable",
+			exp:      n.Execution.JobName,
+			template: "{{.JobName}}",
+		},
+		{
+			desc:     "ReportingNode template variable",
+			exp:      n.Config.NodeName,
+			template: "{{.ReportingNode}}",
+		},
+		{
+			desc:     "StartTime template variable",
+			exp:      fmt.Sprintf("%s", n.Execution.StartedAt),
+			template: "{{.StartTime}}",
+		},
+		{
+			desc:     "FinishedAt template variable",
+			exp:      fmt.Sprintf("%s", n.Execution.FinishedAt),
+			template: "{{.FinishedAt}}",
+		},
+		{
+			desc:     "Success template variable",
+			exp:      fmt.Sprintf("%t", n.Execution.Success),
+			template: "{{.Success}}",
+		},
+		{
+			desc:     "NodeName template variable",
+			exp:      n.Execution.NodeName,
+			template: "{{.NodeName}}",
+		},
+		{
+			desc:     "Output template variable",
+			exp:      fmt.Sprintf("%s", n.Execution.Output),
+			template: "{{.Output}}",
+		},
+	}
 }


### PR DESCRIPTION
- Added template for email output `mail_payload`
- Added template variables:
	- JobName
	- ReportingNode
	- StartTime
	- FinishedAt
	- Success
	- NodeName
	- Output