### PR TITLE
FIX docker-compose to use Zookeeper as coordinator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,22 +2,24 @@
 version: '2'
 services:
   # Uncomment to use etcd
-  etcd:
-    image: microbox/etcd
-    ports:
-      - "4001"
-    volumes:
-      - ./etcd.data:/data
-    command: -name=dkron1
+  #etcd:
+  #  image: microbox/etcd
+  #  ports:
+  #    - "4001"
+  #  volumes:
+  #    - ./etcd.data:/data
+  #  command: -name=dkron1
 
-  consul:
-    image: consul
-    ports:
-      - "8500"
-      - "8300"
-    hostname: node1
-    command: agent -server -bootstrap -ui-dir=/ui -client=0.0.0.0
+  # Uncomment to use consul
+  #consul:
+  #  image: consul
+  #  ports:
+  #    - "8500"
+  #    - "8300"
+  #  hostname: node1
+  #  command: agent -server -bootstrap -ui-dir=/ui -client=0.0.0.0
 
+  # Uncomment to use zookeeper
   zk:
     image: zookeeper
     ports:
@@ -40,8 +42,8 @@ services:
     environment:
       - GODEBUG=netdns=go
     # Uncomment to use consul
-    command: bash -c "go build -o dkron-processor-log ./builtin/bins/processor-log && go build -o dkron-processor-syslog ./builtin/bins/processor-syslog && go build -o dkron-processor-files ./builtin/bins/processor-files && go build *.go && ./main agent -server -backend=consul -backend-machine=consul:8500 -join=dkron:8946 -log-level=debug"
+    # command: bash -c "go build -o dkron-processor-log ./builtin/bins/processor-log && go build -o dkron-processor-syslog ./builtin/bins/processor-syslog && go build -o dkron-processor-files ./builtin/bins/processor-files && go build *.go && ./main agent -server -backend=consul -backend-machine=consul:8500 -join=dkron:8946 -log-level=debug"
     # Uncomment to use etcd
     # command: bash -c "go build *.go && ./main agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron:8946 -log-level=debug"
     # Uncomment to use zk
-    # command: bash -c "go build *.go && ./main agent -server -backend=zk -backend-machine=zk:2181 -join=dkron:8946 -log-level=debug"
+    command: bash -c "go build *.go && ./main agent -server -backend=zk -backend-machine=zk:2181 -join=dkron:8946 -log-level=debug"


### PR DESCRIPTION
Docker-compose script does not run by default, the proposed changes would run Dkron with zookeeper as the default coordinator, and will not unnecessarily download consul/etcd

- commented out consul init script, uncommented zookeeper init script
- commented out etcd and consul services as they are not needed.
- added `Uncomment to use consul` comment above consul service
- added `Uncomment to use zk` comment above zookeeper service