### PR TITLE
Return empty list instead of null for empty job listing

### DIFF
--- a/dkron/store.go
+++ b/dkron/store.go
@@ -182,7 +182,7 @@ func (s *Store) GetJobs() ([]*Job, error) {
 	if err != nil {
 		if err == store.ErrKeyNotFound {
 			log.Debug("store: No jobs found")
-			return nil, nil
+			return []*Job{}, nil
 		}
 		return nil, err
 	}

--- a/dkron/store_test.go
+++ b/dkron/store_test.go
@@ -23,11 +23,19 @@ func TestStore(t *testing.T) {
 		Disabled: true,
 	}
 
+	// Check that we still get an empty job list
+	jobs, err := store.GetJobs()
+	if err != nil {
+		t.Fatalf("error getting jobs: %s", err)
+	} else if jobs == nil {
+		t.Fatal("jobs empty, expecting empty slice")
+	}
+
 	if err := store.SetJob(testJob); err != nil {
 		t.Fatalf("error creating job: %s", err)
 	}
 
-	jobs, err := store.GetJobs()
+	jobs, err = store.GetJobs()
 	if err != nil {
 		t.Fatalf("error getting jobs: %s", err)
 	}


### PR DESCRIPTION
- If we use a new namespace and then call `http://host:port/v1/jobs`, `null`
  will be returned instead of valid JSON `[]`