### PR TITLE
Add notification rules for jobs

### DIFF
--- a/dkron/job.go
+++ b/dkron/job.go
@@ -80,6 +80,9 @@ type Job struct {
 
 	// Processors to use for this job
 	Processors map[string]PluginConfig `json:"processors"`
+
+	// Notify condition (success/failure)
+	NotifyOn string `json:"notify_on"`
 }
 
 // Run the job

--- a/dkron/notifier.go
+++ b/dkron/notifier.go
@@ -31,6 +31,10 @@ func Notification(config *Config, execution *Execution, exGroup []*Execution, jo
 }
 
 func (n *Notifier) Send() {
+	if (n.Job.NotifyOn == "success" && !n.Execution.Success) ||
+		(n.Job.NotifyOn == "failure" && n.Execution.Success) {
+		return
+	}
 	if n.Config.MailHost != "" && n.Config.MailPort != 0 && n.Job.OwnerEmail != "" {
 		n.sendExecutionEmail()
 	}

--- a/dkron/notifier_test.go
+++ b/dkron/notifier_test.go
@@ -147,3 +147,87 @@ var templateTestCases = func(n *Notifier) []templateTestCase {
 		},
 	}
 }
+
+func TestNotifier_notifyOnSuccessPass(t *testing.T) {
+	notified := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
+		notified = true
+	}))
+	defer ts.Close()
+	c := &Config{
+		WebhookURL:     ts.URL,
+		WebhookPayload: `payload={"text": "{{.Report}}"}`,
+		WebhookHeaders: []string{"Content-Type: application/x-www-form-urlencoded"},
+	}
+
+	n := Notification(c, &Execution{Success: true}, []*Execution{}, &Job{NotifyOn: "success"})
+	n.Send()
+
+	if !notified {
+		t.Errorf("Expected notified to be true")
+	}
+}
+
+func TestNotifier_notifyOnSuccessFail(t *testing.T) {
+	notified := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
+		notified = true
+	}))
+	defer ts.Close()
+	c := &Config{
+		WebhookURL:     ts.URL,
+		WebhookPayload: `payload={"text": "{{.Report}}"}`,
+		WebhookHeaders: []string{"Content-Type: application/x-www-form-urlencoded"},
+	}
+
+	n := Notification(c, &Execution{Success: false}, []*Execution{}, &Job{NotifyOn: "success"})
+	n.Send()
+
+	if notified {
+		t.Errorf("Expected notified to be false")
+	}
+}
+
+func TestNotifier_notifyOnFailurePass(t *testing.T) {
+	notified := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
+		notified = true
+	}))
+	defer ts.Close()
+	c := &Config{
+		WebhookURL:     ts.URL,
+		WebhookPayload: `payload={"text": "{{.Report}}"}`,
+		WebhookHeaders: []string{"Content-Type: application/x-www-form-urlencoded"},
+	}
+
+	n := Notification(c, &Execution{Success: false}, []*Execution{}, &Job{NotifyOn: "failure"})
+	n.Send()
+
+	if !notified {
+		t.Errorf("Expected notified to be true")
+	}
+}
+
+func TestNotifier_notifyOnFailureFail(t *testing.T) {
+	notified := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
+		notified = true
+	}))
+	defer ts.Close()
+	c := &Config{
+		WebhookURL:     ts.URL,
+		WebhookPayload: `payload={"text": "{{.Report}}"}`,
+		WebhookHeaders: []string{"Content-Type: application/x-www-form-urlencoded"},
+	}
+
+	n := Notification(c, &Execution{Success: true}, []*Execution{}, &Job{NotifyOn: "failure"})
+	n.Send()
+
+	if notified {
+		t.Errorf("Expected notified to be false")
+	}
+}


### PR DESCRIPTION
- Adds `notify_on` to the job defintion where either `success` or `failure` can
  be specified to supress output for that job depending on the execution outcome
	- If anything else other than `success` or `failure` is used, it will be
	  ignored
X-Github-Closes: #112