### PR TITLE
Add ready signal to AgentCommand

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -54,6 +54,7 @@ type AgentCommand struct {
 	eventCh   chan serf.Event
 	sched     *Scheduler
 	candidate *leadership.Candidate
+	ready     bool
 }
 
 func (a *AgentCommand) Help() string {
@@ -302,7 +303,7 @@ func (a *AgentCommand) Run(args []string) int {
 		a.participate()
 	}
 	go a.eventLoop()
-
+	a.ready = true
 	return a.handleSignals()
 }
 

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -36,7 +36,12 @@ func setupAPITest(t *testing.T) (chan<- struct{}, <-chan int) {
 		resultCh <- a.Run(args)
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	for {
+		if a.ready {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	return shutdownCh, resultCh
 }


### PR DESCRIPTION
- Fixes testing issues where agent is not ready when the tests
  are run
- X-Github-Closes: #191