### PR TITLE
fix_RPC_server_listen_address

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -452,6 +452,11 @@ func (a *AgentCommand) listServers() []serf.Member {
 	return members
 }
 
+func (a *AgentCommand) GetBindIP() (string, error) {
+	bindIP, _, err := a.config.AddrParts(a.config.BindAddr)
+	return bindIP, err
+}
+
 // Listens to events from Serf and handle the event.
 func (a *AgentCommand) eventLoop() {
 	serfShutdownCh := a.serf.ShutdownCh()
@@ -525,7 +530,10 @@ func (a *AgentCommand) eventLoop() {
 						"at":      query.LTime,
 					}).Debug("agent: RPC Config requested")
 
-					query.Respond([]byte(a.getRPCAddr()))
+					err := query.Respond([]byte(a.getRPCAddr()))
+					if err != nil {
+						log.WithError(err).Error("agent: query.Respond")
+					}
 				}
 			}
 

--- a/dkron/rpc.go
+++ b/dkron/rpc.go
@@ -2,6 +2,7 @@ package dkron
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/rpc"
@@ -135,8 +136,13 @@ func listenRPC(a *AgentCommand) {
 		agent: a,
 	}
 
+	bindIp, err := a.GetBindIP()
+	if err != nil {
+		log.Fatal("rpc:", err)
+	}
+	RPCAddr := fmt.Sprintf("%s:%d", bindIp, a.config.RPCPort)
 	log.WithFields(logrus.Fields{
-		"rpc_addr": a.getRPCAddr(),
+		"rpc_addr": RPCAddr,
 	}).Debug("rpc: Registering RPC server")
 
 	rpc.Register(r)
@@ -157,7 +163,7 @@ func listenRPC(a *AgentCommand) {
 	// workaround
 	http.DefaultServeMux = oldMux
 
-	l, e := net.Listen("tcp", a.getRPCAddr())
+	l, e := net.Listen("tcp", RPCAddr)
 	if e != nil {
 		log.Fatal("rpc:", e)
 	}


### PR DESCRIPTION
1, When the RPC starts, it calls a.getRPCAddr() to get the RPC address, the problem is that if we set `advertise_addr` option, the `a.getRPCAddr()` will return the address of `advertise_addr` which is Incorrect.  it SHOULD use the original bind ip, i added a function `GetBindIP()` for this.
2,  Line agent.go:528, it didn't check the error when invokes the `query.Respond` which could hide some exceptions ,  fixed that here.
