### PR TITLE
A new parameter for advertise_rpc_port

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -89,6 +89,7 @@ Options:
   -ui-dir                         Directory from where to serve Web UI
   -rpc-port=6868                  RPC Port used to communicate with clients. Only used when server.
                                   The RPC IP Address will be the same as the bind address.
+  -advertise-rpc-port             Use the value of -rpc-port by default
 
   -mail-host                      Mail server host address to use for notifications.
   -mail-port                      Mail server port.
@@ -200,6 +201,10 @@ func (a *AgentCommand) setupSerf() *serf.Serf {
 			a.Ui.Error(fmt.Sprintf("Invalid advertise address: %s", err))
 			return nil
 		}
+	}
+	//Ues the value of "RPCPort" if AdvertiseRPCPort has not been set 
+	if config.AdvertiseRPCPort <= 0 {
+		config.AdvertiseRPCPort = config.RPCPort
 	}
 
 	encryptKey, err := config.EncryptBytes()
@@ -615,8 +620,9 @@ func (a *AgentCommand) setExecution(payload []byte) *Execution {
 
 // This function is called when a client request the RPCAddress
 // of the current member.
+// in marathon, it would return the host's IP and advertise RPC port
 func (a *AgentCommand) getRPCAddr() string {
 	bindIp := a.serf.LocalMember().Addr
 
-	return fmt.Sprintf("%s:%d", bindIp, a.config.RPCPort)
+	return fmt.Sprintf("%s:%d", bindIp, a.config.AdvertiseRPCPort)
 }

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Keyspace              string
 	UIDir                 string
 	RPCPort               int
+	AdvertiseRPCPort      int
 
 	MailHost     string
 	MailPort     uint16
@@ -103,6 +104,7 @@ func NewConfig(args []string, agent *AgentCommand) *Config {
 	cmdFlags.String("ui-dir", ".", "directory to serve web UI")
 	viper.SetDefault("ui_dir", cmdFlags.Lookup("ui-dir").Value)
 	viper.SetDefault("rpc_port", cmdFlags.Int("rpc-port", 6868, "RPC port"))
+	viper.SetDefault("advertise_rpc_port", cmdFlags.Int("advertise-rpc-port", 0, "advertise RPC port"))
 
 	// Notifications
 	cmdFlags.String("mail-host", "", "notification mail server host")
@@ -158,21 +160,22 @@ func ReadConfig(agent *AgentCommand) *Config {
 	InitLogger(viper.GetString("log_level"), nodeName)
 
 	return &Config{
-		NodeName:        nodeName,
-		BindAddr:        viper.GetString("bind_addr"),
-		AdvertiseAddr:   viper.GetString("advertise_addr"),
-		HTTPAddr:        viper.GetString("http_addr"),
-		Discover:        viper.GetString("discover"),
-		Backend:         viper.GetString("backend"),
-		BackendMachines: viper.GetStringSlice("backend_machine"),
-		Server:          server,
-		Profile:         viper.GetString("profile"),
-		StartJoin:       viper.GetStringSlice("join"),
-		Tags:            tags,
-		Keyspace:        viper.GetString("keyspace"),
-		EncryptKey:      viper.GetString("encrypt"),
-		UIDir:           viper.GetString("ui_dir"),
-		RPCPort:         viper.GetInt("rpc_port"),
+		NodeName:         nodeName,
+		BindAddr:         viper.GetString("bind_addr"),
+		AdvertiseAddr:    viper.GetString("advertise_addr"),
+		HTTPAddr:         viper.GetString("http_addr"),
+		Discover:         viper.GetString("discover"),
+		Backend:          viper.GetString("backend"),
+		BackendMachines:  viper.GetStringSlice("backend_machine"),
+		Server:           server,
+		Profile:          viper.GetString("profile"),
+		StartJoin:        viper.GetStringSlice("join"),
+		Tags:             tags,
+		Keyspace:         viper.GetString("keyspace"),
+		EncryptKey:       viper.GetString("encrypt"),
+		UIDir:            viper.GetString("ui_dir"),
+		RPCPort:          viper.GetInt("rpc_port"),
+		AdvertiseRPCPort: viper.GetInt("advertise_rpc_port"),
 
 		MailHost:     viper.GetString("mail_host"),
 		MailPort:     uint16(viper.GetInt("mail_port")),


### PR DESCRIPTION
We had a issue when we run the dkron services in marathon framework.
Because the marathon/docker  have the mapping for the RPC server from container IP:Port to Host IP:Port, such as `10.0.2.3:6868 -> 172.217.1.78:13123` in which the port `13123` is dynamically assigned by docker, other agents can NOT access the 10.0.2.3:6868 since it's inside the container, the agents should connect  the port `:13123` instead of `:6868`.
We already have the -advertise address( IP+Port) for `8946`, but not for RPC port.
This PR added a new parameter `advertise_rpc_port` whose value should be '13123' in above example.
I am not 100% sure it's the best solution for the issue, but it does work in our marathon cluster.

