### PR TITLE
Telemetry

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -291,6 +291,7 @@ func (a *AgentCommand) Run(args []string) int {
 	}
 	a.join(a.config.StartJoin, true)
 
+	initMetrics(a.config)
 	// Expose the node name
 	expNode.Set(a.config.NodeName)
 

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	metrics "github.com/armon/go-metrics"
 	"github.com/docker/leadership"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/serf"
@@ -291,7 +292,10 @@ func (a *AgentCommand) Run(args []string) int {
 	}
 	a.join(a.config.StartJoin, true)
 
-	initMetrics(a.config)
+	if i := initMetrics(a); i != 0 {
+		return i
+	}
+
 	// Expose the node name
 	expNode.Set(a.config.NodeName)
 
@@ -405,6 +409,7 @@ func (a *AgentCommand) participate() {
 // Leader election routine
 func (a *AgentCommand) runForElection() {
 	log.Info("agent: Running for election")
+	defer metrics.MeasureSince([]string{"agent", "runForElection"}, time.Now())
 	electedCh, errCh := a.candidate.RunForElection()
 
 	for {
@@ -412,16 +417,19 @@ func (a *AgentCommand) runForElection() {
 		case isElected := <-electedCh:
 			if isElected {
 				log.Info("agent: Cluster leadership acquired")
+				metrics.IncrCounter([]string{"agent", "leadership_acquired"}, 1)
 				// If this server is elected as the leader, start the scheduler
 				a.schedule()
 			} else {
 				log.Info("agent: Cluster leadership lost")
+				metrics.IncrCounter([]string{"agent", "leadership_lost"}, 1)
 				// Always stop the schedule of this server to prevent multiple servers with the scheduler on
 				a.sched.Stop()
 			}
 
 		case err := <-errCh:
 			log.WithError(err).Debug("Leader election failed, channel is probably closed")
+			metrics.IncrCounter([]string{"agent", "election", "failure"}, 1)
 			// Always stop the schedule of this server to prevent multiple servers with the scheduler on
 			a.sched.Stop()
 			return
@@ -463,6 +471,7 @@ func (a *AgentCommand) eventLoop() {
 			log.WithFields(logrus.Fields{
 				"event": e.String(),
 			}).Debug("agent: Received event")
+			metrics.AddSample([]string{"agent", "event_received", e.String()}, 1)
 
 			// Log all member events
 			if failed, ok := e.(serf.MemberEvent); ok {

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	WebhookURL     string
 	WebhookPayload string
 	WebhookHeaders []string
+
+	DogStatsdAddr string
+	StatsdAddr    string
 }
 
 // This is the default port that we use for Serf communication
@@ -125,6 +128,11 @@ func NewConfig(args []string, agent *AgentCommand) *Config {
 	webhookHeaders := &AppendSliceValue{}
 	cmdFlags.Var(webhookHeaders, "webhook-header", "notification webhook additional header")
 
+	cmdFlags.String("dog-statsd-addr", "", "DataDog Agent address")
+	viper.SetDefault("dog_statsd_addr", cmdFlags.Lookup("dog-statsd-addr").Value)
+	cmdFlags.String("statsd-addr", "", "Statsd Address")
+	viper.SetDefault("statsd_addr", cmdFlags.Lookup("statsd-addr").Value)
+
 	if err := cmdFlags.Parse(args); err != nil {
 		log.Fatal(err)
 	}
@@ -184,6 +192,9 @@ func ReadConfig(agent *AgentCommand) *Config {
 		WebhookURL:     viper.GetString("webhook_url"),
 		WebhookPayload: viper.GetString("webhook_payload"),
 		WebhookHeaders: viper.GetStringSlice("webhook_headers"),
+
+		DogStatsdAddr: viper.GetString("dog_statsd_addr"),
+		StatsdAddr:    viper.GetString("statsd_addr"),
 	}
 }
 

--- a/dkron/metrics.go
+++ b/dkron/metrics.go
@@ -5,28 +5,33 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/datadog"
 )
 
-func initMetrics(config *Config) {
+func initMetrics(a *AgentCommand) int {
 	// Setup the inmem sink and signal handler
 	inm := metrics.NewInmemSink(10*time.Second, time.Minute)
 	metrics.DefaultInmemSignal(inm)
 
 	var fanout metrics.FanoutSink
-	// Configure the DogStatsd sink
-	if config.DogStatsdAddr != "" {
-		var tags []string
 
-		if config.DogStatsdTags != nil {
-			tags = config.DogStatsdTags
-		}
-
-		sink, err := datadog.NewDogStatsdSink(config.DogStatsdAddr, metricsConf.HostName)
+	// Configure the statsd sink
+	if a.config.StatsdAddr != "" {
+		sink, err := metrics.NewStatsdSink(a.config.StatsdAddr)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Failed to start DogStatsd sink. Got: %s", err))
+			a.Ui.Error(fmt.Sprintf("Failed to start statsd sink. Got: %s", err))
 			return 1
 		}
-		sink.SetTags(tags)
+		fanout = append(fanout, sink)
+	}
+
+	// Configure the DogStatsd sink
+	if a.config.DogStatsdAddr != "" {
+		sink, err := datadog.NewDogStatsdSink(a.config.DogStatsdAddr, a.config.NodeName)
+		if err != nil {
+			a.Ui.Error(fmt.Sprintf("Failed to start DogStatsd sink. Got: %s", err))
+			return 1
+		}
 		fanout = append(fanout, sink)
 	}
 
@@ -37,4 +42,6 @@ func initMetrics(config *Config) {
 	} else {
 		metrics.NewGlobal(metrics.DefaultConfig("dkron"), inm)
 	}
+
+	return 0
 }

--- a/dkron/metrics.go
+++ b/dkron/metrics.go
@@ -1,0 +1,40 @@
+package dkron
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/armon/go-metrics"
+)
+
+func initMetrics(config *Config) {
+	// Setup the inmem sink and signal handler
+	inm := metrics.NewInmemSink(10*time.Second, time.Minute)
+	metrics.DefaultInmemSignal(inm)
+
+	var fanout metrics.FanoutSink
+	// Configure the DogStatsd sink
+	if config.DogStatsdAddr != "" {
+		var tags []string
+
+		if config.DogStatsdTags != nil {
+			tags = config.DogStatsdTags
+		}
+
+		sink, err := datadog.NewDogStatsdSink(config.DogStatsdAddr, metricsConf.HostName)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to start DogStatsd sink. Got: %s", err))
+			return 1
+		}
+		sink.SetTags(tags)
+		fanout = append(fanout, sink)
+	}
+
+	// Initialize the global sink
+	if len(fanout) > 0 {
+		fanout = append(fanout, inm)
+		metrics.NewGlobal(metrics.DefaultConfig("dkron"), fanout)
+	} else {
+		metrics.NewGlobal(metrics.DefaultConfig("dkron"), inm)
+	}
+}

--- a/dkron/rpc.go
+++ b/dkron/rpc.go
@@ -5,8 +5,10 @@ import (
 	"net"
 	"net/http"
 	"net/rpc"
+	"time"
 
 	"github.com/Sirupsen/logrus"
+	metrics "github.com/armon/go-metrics"
 	"github.com/docker/libkv/store"
 	"github.com/hashicorp/serf/serf"
 )
@@ -20,6 +22,7 @@ type RPCServer struct {
 }
 
 func (rpcs *RPCServer) GetJob(jobName string, job *Job) error {
+	defer metrics.MeasureSince([]string{"rpc", "GetJob"}, time.Now())
 	log.WithFields(logrus.Fields{
 		"job": jobName,
 	}).Debug("rpc: Received GetJob")
@@ -37,6 +40,7 @@ func (rpcs *RPCServer) GetJob(jobName string, job *Job) error {
 }
 
 func (rpcs *RPCServer) ExecutionDone(execution Execution, reply *serf.NodeResponse) error {
+	defer metrics.MeasureSince([]string{"rpc", "ExecutionDone"}, time.Now())
 	log.WithFields(logrus.Fields{
 		"group": execution.Group,
 		"job":   execution.JobName,
@@ -170,6 +174,7 @@ type RPCClient struct {
 }
 
 func (rpcc *RPCClient) callExecutionDone(execution *Execution) error {
+	defer metrics.MeasureSince([]string{"rpc", "callExecutionDone"}, time.Now())
 	client, err := rpc.DialHTTP("tcp", rpcc.ServerAddr)
 	if err != nil {
 		log.WithFields(logrus.Fields{
@@ -195,6 +200,7 @@ func (rpcc *RPCClient) callExecutionDone(execution *Execution) error {
 }
 
 func (rpcc *RPCClient) GetJob(jobName string) (*Job, error) {
+	defer metrics.MeasureSince([]string{"rpc", "callGetJob"}, time.Now())
 	client, err := rpc.DialHTTP("tcp", rpcc.ServerAddr)
 	if err != nil {
 		log.WithFields(logrus.Fields{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,20 +24,30 @@ services:
       - "2181"
     hostname: node1
 
+  dkron_build:
+    build: .
+    image: dkron
+    volumes:
+     - ./:/gopath/src/github.com/victorcoder/dkron
+    environment:
+      - GODEBUG=netdns=go
+    command: bash -c "GOBIN=`pwd` go clean -i ./builtin/... && GOBIN=`pwd` go install ./builtin/... && go build -o main"
+  
   dkron:
+    image: dkron
     depends_on:
+      - dkron_build
       - consul
       - etcd
       - zk
     ports:
       - "8080"
-    build: .
     volumes:
      - ./:/gopath/src/github.com/victorcoder/dkron
     environment:
       - GODEBUG=netdns=go
     # Uncomment to use consul
-    command: bash -c "GOBIN=`pwd` go clean -i ./builtin/... && GOBIN=`pwd` go install ./builtin/... && go build -o main && ./main agent -server -backend=consul -backend-machine=consul:8500 -join=dkron:8946 -log-level=debug"
+    command: ./main agent -server -backend=consul -backend-machine=consul:8500 -join=dkron:8946 -log-level=debug
     # Uncomment to use etcd
     # command: bash -c "GOBIN=`pwd` go clean -i ./builtin/... && GOBIN=`pwd` go install ./builtin/... && go build -o main && ./main agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron:8946 -log-level=debug"
     # Uncomment to use zk

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,14 @@
-hash: a760cb97ebcf82644166c6748d040802fbe9b3614e4396bd55f06f696a4486ae
-updated: 2016-11-09T22:15:10.57771928+01:00
+hash: e4f1a3b9e2881fadbfdabe1acdbd7678374481c4eb595efb5a07821852530d4d
+updated: 2017-01-11T12:25:25.943085711+01:00
 imports:
 - name: bitbucket.org/kardianos/osext
   version: 816c96ec6fef6a0cd72c9395d192c4bd0d918753
 - name: github.com/armon/circbuf
   version: f092b4f207b6e5cce0569056fba9e1a2735cb6cf
 - name: github.com/armon/go-metrics
-  version: a54701ebec11868993bc198c3f315353e9de2ed6
+  version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
+  subpackages:
+  - datadog
 - name: github.com/BurntSushi/toml
   version: 2ceedfee35ad3848e49308ab0c9a4f640cfb5fb2
 - name: github.com/carbocation/interpose
@@ -14,11 +16,15 @@ imports:
 - name: github.com/coreos/etcd
   version: 56b75844186dbf1464c679829787b935c0ba73ec
   subpackages:
+  - Godeps/_workspace/src/github.com/ugorji/go/codec
+  - Godeps/_workspace/src/golang.org/x/net/context
   - client
   - pkg/pathutil
   - pkg/types
-  - Godeps/_workspace/src/github.com/ugorji/go/codec
-  - Godeps/_workspace/src/golang.org/x/net/context
+- name: github.com/DataDog/datadog-go
+  version: 6ea09a7540648568ce58b3d00eb1da133c2dcdd7
+  subpackages:
+  - statsd
 - name: github.com/deckarep/golang-set
   version: 2e9696acaf8dc5b879518fbed0450778cfef4ec6
 - name: github.com/docker/leadership

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,8 +6,6 @@ import:
   version: 0.9.0
 - package: github.com/armon/circbuf
   version: f092b4f207b6e5cce0569056fba9e1a2735cb6cf
-- package: github.com/armon/go-metrics
-  version: a54701ebec11868993bc198c3f315353e9de2ed6
 - package: github.com/carbocation/interpose
   version: 50c09d12f8624ab10532f931cb630d0bf5f7c2c7
 - package: github.com/coreos/etcd
@@ -90,3 +88,7 @@ import:
 - package: github.com/hashicorp/go-plugin
 - package: bitbucket.org/kardianos/osext
 - package: github.com/hashicorp/go-syslog
+- package: github.com/armon/go-metrics
+  version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
+  subpackages:
+  - datadog


### PR DESCRIPTION
Allow emitting metrics to statsd, datadog and runtime metrics.

Start with a set of basic metrics, more can be added based on needs.