### PR TITLE
Leverage docker layer cache to build dkron image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ WORKDIR /gopath/src/github.com/victorcoder/dkron
 ENV GOPATH /gopath
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
-COPY . ./
+COPY glide.* ./
 RUN glide install
 
+COPY . ./
 RUN go build *.go
 CMD ["/gopath/src/github.com/victorcoder/dkron/main"]


### PR DESCRIPTION
This patch improves docker image build time, by leveraging docker layer
cache. Dependencies installation step can be skipped if files glide.lock
and glide.yaml were not changed since last build. Cheers