### PR TITLE
Remove duplicated dependency install in travis cfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ services:
   - docker
 
 script:
-  - docker-compose run dkron glide install
+  - docker-compose build dkron
   - scripts/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ services:
 
 script:
   - docker-compose build dkron
+  - docker-compose run dkron ./main version
   - scripts/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ services:
 
 script:
   - docker-compose build dkron
-  - docker-compose run dkron ./main version
+  - docker-compose run dkron true
   - scripts/test.sh
+  - docker-compose run dkron bash -c "GOBIN=`pwd` go clean -i ./builtin/... && GOBIN=`pwd` go install ./builtin/... && go build -o main"


### PR DESCRIPTION
Dependencies were installed twice in travis build. This patch improves
build time by removing second execution.