### PR TITLE
Fix etcd leadership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.8
 MAINTAINER Victor Castell <victor@victorcastell.com>
 
 EXPOSE 8080 8946

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -207,7 +207,7 @@ func (a *AgentCommand) setupSerf() *serf.Serf {
 			return nil
 		}
 	}
-	//Ues the value of "RPCPort" if AdvertiseRPCPort has not been set 
+	//Ues the value of "RPCPort" if AdvertiseRPCPort has not been set
 	if config.AdvertiseRPCPort <= 0 {
 		config.AdvertiseRPCPort = config.RPCPort
 	}
@@ -359,11 +359,6 @@ WAIT:
 	a.Ui.Output("Gracefully shutting down agent...")
 	log.Info("agent: Gracefully shutting down agent...")
 	go func() {
-		// If we're exiting a server
-		if a.config.Server {
-			// Stop running for leader election
-			a.candidate.Stop()
-		}
 		if err := a.serf.Leave(); err != nil {
 			a.Ui.Error(fmt.Sprintf("Error: %s", err))
 			log.Error(fmt.Sprintf("Error: %s", err))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
   etcd:
     image: quay.io/coreos/etcd
     ports:
-      - "4001"
+      - "2379"
     volumes:
       - ./etcd.data:/data
-    command: etcd -name=dkron1 -advertise-client-urls http://etcd:2379,http://etcd:4001 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001
+    command: etcd -name=dkron1 -advertise-client-urls http://etcd:2379,http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379
 
   consul:
     image: consul
@@ -49,6 +49,6 @@ services:
     # Uncomment to use consul
     command: ./main agent -server -backend=consul -backend-machine=consul:8500 -join=dkron:8946 -log-level=debug
     # Uncomment to use etcd
-    # command: ./main agent -server -backend=etcd -backend-machine=etcd:4001 -join=dkron:8946 -log-level=debug
+    # command: ./main agent -server -backend=etcd -backend-machine=etcd:2379 -join=dkron:8946 -log-level=debug
     # Uncomment to use zk
     # command: ./main agent -server -backend=zk -backend-machine=zk:2181 -join=dkron:8946 -log-level=debug


### PR DESCRIPTION
For some reason etcd doesn't detect that the leader key lock TTL is expired unless the leader client stops refreshing the key TTL without unlocking the key.

This is probably a bug in docker/libkv library, removing the unlock code works well in all three backends.

fix #130 