### PR TITLE
Fix "query exceeds limit of 1024 bytes" in retries

### DIFF
--- a/dkron/rpc.go
+++ b/dkron/rpc.go
@@ -101,6 +101,10 @@ func (rpcs *RPCServer) ExecutionDone(execution Execution, reply *serf.NodeRespon
 	if !execution.Success && execution.Attempt < job.Retries+1 {
 		execution.Attempt++
 
+		// Keep all execution properties intact except the last output
+		// as it could exceed serf query limits.
+		execution.Output = []byte{}
+
 		log.WithFields(logrus.Fields{
 			"attempt":   execution.Attempt,
 			"execution": execution,


### PR DESCRIPTION
When retying a failed job, the last output is present in the next retry run job query, this makes serf complaint about the message size preventing the rety to occur.

This fixes it cleaning up the output of the last attempt.

Fixes #249 