### PR TITLE
Parametrise subject prefix in mail notifications

### DIFF
--- a/debian/etc/dkron/dkron.json.example
+++ b/debian/etc/dkron/dkron.json.example
@@ -22,5 +22,6 @@
   "mail_port": 25,
   "mail_username": "mailuser",
   "mail_password": "mailpassword",
-  "mail_from": "cron@example.com"
+  "mail_from": "cron@example.com",
+  "mail_subject_prefix": "[Dkron]"
 }

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -38,12 +38,13 @@ type Config struct {
 	RPCPort               int
 	AdvertiseRPCPort      int
 
-	MailHost     string
-	MailPort     uint16
-	MailUsername string
-	MailPassword string
-	MailFrom     string
-	MailPayload  string
+	MailHost          string
+	MailPort          uint16
+	MailUsername      string
+	MailPassword      string
+	MailFrom          string
+	MailPayload       string
+	MailSubjectPrefix string
 
 	WebhookURL     string
 	WebhookPayload string
@@ -125,6 +126,8 @@ func NewConfig(args []string, agent *AgentCommand) *Config {
 	viper.SetDefault("mail_from", cmdFlags.Lookup("mail-from").Value)
 	cmdFlags.String("mail-payload", "", "notification mail payload")
 	viper.SetDefault("mail_payload", cmdFlags.Lookup("mail-payload").Value)
+	cmdFlags.String("mail-subject-prefix", "[Dkron]", "notification mail subject prefix")
+	viper.SetDefault("mail_subject_prefix", cmdFlags.Lookup("mail-subject-prefix").Value)
 
 	cmdFlags.String("webhook-url", "", "notification webhook url")
 	viper.SetDefault("webhook_url", cmdFlags.Lookup("webhook-url").Value)
@@ -192,12 +195,13 @@ func ReadConfig(agent *AgentCommand) *Config {
 		RPCPort:          viper.GetInt("rpc_port"),
 		AdvertiseRPCPort: viper.GetInt("advertise_rpc_port"),
 
-		MailHost:     viper.GetString("mail_host"),
-		MailPort:     uint16(viper.GetInt("mail_port")),
-		MailUsername: viper.GetString("mail_username"),
-		MailPassword: viper.GetString("mail_password"),
-		MailFrom:     viper.GetString("mail_from"),
-		MailPayload:  viper.GetString("mail_payload"),
+		MailHost:          viper.GetString("mail_host"),
+		MailPort:          uint16(viper.GetInt("mail_port")),
+		MailUsername:      viper.GetString("mail_username"),
+		MailPassword:      viper.GetString("mail_password"),
+		MailFrom:          viper.GetString("mail_from"),
+		MailPayload:       viper.GetString("mail_payload"),
+		MailSubjectPrefix: viper.GetString("mail_subject_prefix"),
 
 		WebhookURL:     viper.GetString("webhook_url"),
 		WebhookPayload: viper.GetString("webhook_payload"),

--- a/dkron/notifier.go
+++ b/dkron/notifier.go
@@ -103,7 +103,7 @@ func (n *Notifier) sendExecutionEmail() {
 	}
 	e := &email.Email{
 		To:      []string{n.Job.OwnerEmail},
-		From:    n.Config.MailSubjectPrefix,
+		From:    n.Config.MailFrom,
 		Subject: fmt.Sprintf("%s%s %s execution report", n.Config.MailSubjectPrefix, n.statusString(n.Execution), n.Execution.JobName),
 		Text:    []byte(data.Bytes()),
 		Headers: textproto.MIMEHeader{},

--- a/dkron/notifier.go
+++ b/dkron/notifier.go
@@ -103,8 +103,8 @@ func (n *Notifier) sendExecutionEmail() {
 	}
 	e := &email.Email{
 		To:      []string{n.Job.OwnerEmail},
-		From:    n.Config.MailFrom,
-		Subject: fmt.Sprintf("[Dkron] %s %s execution report", n.statusString(n.Execution), n.Execution.JobName),
+		From:    n.Config.MailSubjectPrefix,
+		Subject: fmt.Sprintf("%s%s %s execution report", n.Config.MailSubjectPrefix, n.statusString(n.Execution), n.Execution.JobName),
 		Text:    []byte(data.Bytes()),
 		Headers: textproto.MIMEHeader{},
 	}

--- a/dkron/notifier_test.go
+++ b/dkron/notifier_test.go
@@ -28,11 +28,12 @@ func TestNotifier_callExecutionWebhook(t *testing.T) {
 
 func TestNotifier_sendExecutionEmail(t *testing.T) {
 	c := &Config{
-		MailHost:     "mailtrap.io",
-		MailPort:     2525,
-		MailUsername: "45326e3b115066bbb",
-		MailPassword: "7f496ed2b06688",
-		MailFrom:     "dkron@dkron.io",
+		MailHost:          "mailtrap.io",
+		MailPort:          2525,
+		MailUsername:      "45326e3b115066bbb",
+		MailPassword:      "7f496ed2b06688",
+		MailFrom:          "dkron@dkron.io",
+		MailSubjectPrefix: "[Test]"
 	}
 
 	job := &Job{

--- a/dkron/notifier_test.go
+++ b/dkron/notifier_test.go
@@ -33,7 +33,7 @@ func TestNotifier_sendExecutionEmail(t *testing.T) {
 		MailUsername:      "45326e3b115066bbb",
 		MailPassword:      "7f496ed2b06688",
 		MailFrom:          "dkron@dkron.io",
-		MailSubjectPrefix: "[Test]"
+		MailSubjectPrefix: "[Test]",
 	}
 
 	job := &Job{

--- a/website/content/basics/configuration.md
+++ b/website/content/basics/configuration.md
@@ -78,6 +78,7 @@ Settings for dkron can be specified in three ways: Using a `config/dkron.json` c
   "mail_port": 25,
   "mail_username": "mailuser",
   "mail_password": "mailpassword",
-  "mail_from": "cron@example.com"
+  "mail_from": "cron@example.com",
+  "mail_subject_prefix": "[Dkron]"
 }
 ```


### PR DESCRIPTION
Allow to configure a custom mail prefix when sending notifications. Currently it is hardcoded to `[Dkron]`. This can be useful to easily distinguish between email notifications from several dkron's clusters running.