### PR TITLE
fixed GetLastExecutionGroup

### DIFF
--- a/dkron/store.go
+++ b/dkron/store.go
@@ -274,16 +274,23 @@ func (s *Store) GetLastExecutionGroup(jobName string) ([]*Execution, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(res) == 0{
+	if len(res) == 0 {
 		return []*Execution{}, nil
 	}
 
+	var lastEx Execution
 	var ex Execution
-	err = json.Unmarshal([]byte(res[len(res)-1].Value), &ex)
-	if err != nil {
-		return nil, err
+	// res does not guarantee any order, so sort them by `StartedAt` time
+	for _, node := range res {
+		err := json.Unmarshal([]byte(node.Value), &ex)
+		if err != nil {
+			return nil, err
+		}
+		if ex.StartedAt.After(lastEx.StartedAt) {
+			lastEx = ex
+		}
 	}
-	return s.GetExecutionGroup(&ex)
+	return s.GetExecutionGroup(&lastEx)
 }
 
 func (s *Store) GetExecutionGroup(execution *Execution) ([]*Execution, error) {

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -280,7 +280,8 @@ func (s *Store) GetLastExecutionGroup(jobName string) ([]*Execution, error) {
 
 	var lastEx Execution
 	var ex Execution
-	// res does not guarantee any order, so sort them by `StartedAt` time
+	// res does not guarantee any order,
+	// so compare them by `StartedAt` time and get the last one
 	for _, node := range res {
 		err := json.Unmarshal([]byte(node.Value), &ex)
 		if err != nil {


### PR DESCRIPTION
Store.GetLastExecutionGroup() could return a random execution because the `executions list` is not in order. This PR fixed this issue by comparing ~~sorting~~ them by `StartedAt` time.
