### PR TITLE
Upgrade Gin to fix logging

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
-	gin "gopkg.in/gin-gonic/gin.v1"
+	gin "github.com/gin-gonic/gin"
 )
 
 const pretty = "pretty"

--- a/dkron/dashboard.go
+++ b/dkron/dashboard.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/gin-contrib/multitemplate"
-	"gopkg.in/gin-gonic/gin.v1"
+	"github.com/gin-gonic/gin"
 )
 
 const (

--- a/dkron/log.go
+++ b/dkron/log.go
@@ -2,6 +2,7 @@ package dkron
 
 import (
 	"github.com/Sirupsen/logrus"
+	"github.com/gin-gonic/gin"
 )
 
 var log = logrus.NewEntry(logrus.New())
@@ -18,4 +19,5 @@ func InitLogger(logLevel string, node string) {
 
 	formattedLogger.Level = level
 	log = logrus.NewEntry(formattedLogger).WithField("node", node)
+	gin.DefaultWriter = log.Writer()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - zk
     ports:
       - "8080"
+      - "8946"
     volumes:
      - ./:/gopath/src/github.com/victorcoder/dkron
     environment:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2121c83a7ff41a2e75d24b0fe6b5420c648659027a15488f2bcffc1f2658cb6b
-updated: 2017-06-29T22:46:27.550387105+02:00
+hash: 50735e5cda0de81d0f9a0a14195559e6e9313daffaf8822c037acb710ddade4a
+updated: 2017-10-18T12:57:13.541232262+02:00
 imports:
 - name: bitbucket.org/kardianos/osext
   version: 816c96ec6fef6a0cd72c9395d192c4bd0d918753
@@ -40,6 +40,8 @@ imports:
   version: 5f834d3672079e82c5f79f42c069475f636d3a11
 - name: github.com/gin-contrib/multitemplate
   version: 753bf9175717da70b3b268251659ad318533d764
+- name: github.com/gin-contrib/sse
+  version: 22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae
 - name: github.com/gin-gonic/gin
   version: e2212d40c62a98b388a5eb48ecbdcf88534688ba
   subpackages:
@@ -133,8 +135,6 @@ imports:
   version: 30de6d19a3bd89a5f38ae4028e23aaa5582648af
   subpackages:
   - unix
-- name: gopkg.in/gin-gonic/gin.v1
-  version: e2212d40c62a98b388a5eb48ecbdcf88534688ba
 - name: gopkg.in/go-playground/validator.v8
   version: c193cecd124b5cc722d7ee5538e945bdb3348435
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -88,8 +88,8 @@ import:
   version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
   subpackages:
   - datadog
-- package: gopkg.in/gin-gonic/gin.v1
-  version: ^1.1.4
+- package: github.com/gin-gonic/gin
+  version: ^1.2
 - package: github.com/gin-contrib/multitemplate
   version: 753bf9175717da70b3b268251659ad318533d764
 - package: github.com/gin-contrib/expvar


### PR DESCRIPTION
New Gin version allows to overwrite the log writter, set it to the dkron log writter.