### PR TITLE
Update plugins.go

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"github.com/Sirupsen/logrus"
 	"github.com/hashicorp/go-plugin"
 	"github.com/victorcoder/dkron/dkron"


### PR DESCRIPTION
change  bitbucket.org/kardianos/osext to github.com/kardianos/osext, the new bitbucket.org/kardianos/osext not supported