### PR TITLE
[FIX] copy dependent job from previous job to new job version

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -126,7 +126,7 @@ func (a *AgentCommand) jobCreateOrUpdateHandler(c *gin.Context) {
 	}
 
 	// Save the job to the store
-	if err = a.store.SetJob(&job); err != nil {
+	if err = a.store.SetJob(&job, ej); err != nil {
 		c.AbortWithError(422, err)
 		return
 	}

--- a/dkron/job_test.go
+++ b/dkron/job_test.go
@@ -26,7 +26,7 @@ func TestJobGetParent(t *testing.T) {
 		Schedule: "@every 2s",
 	}
 
-	if err := store.SetJob(parentTestJob); err != nil {
+	if err := store.SetJob(parentTestJob,nil); err != nil {
 		t.Fatalf("error creating job: %s", err)
 	}
 
@@ -36,7 +36,7 @@ func TestJobGetParent(t *testing.T) {
 		ParentJob: "parent_test",
 	}
 
-	err = store.SetJob(dependentTestJob)
+	err = store.SetJob(dependentTestJob,nil)
 	assert.NoError(t, err)
 
 	err = store.SetJobDependencyTree(dependentTestJob, nil)
@@ -55,7 +55,7 @@ func TestJobGetParent(t *testing.T) {
 
 	dependentTestJob.ParentJob = ""
 	dependentTestJob.Schedule = "@every 2m"
-	err = store.SetJob(dependentTestJob)
+	err = store.SetJob(dependentTestJob,nil)
 	assert.NoError(t, err)
 
 	err = store.SetJobDependencyTree(dependentTestJob, ej)

--- a/dkron/queries.go
+++ b/dkron/queries.go
@@ -2,7 +2,7 @@ package dkron
 
 import (
 	"encoding/json"
-
+  "bytes"
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 	"github.com/hashicorp/serf/serf"
@@ -50,9 +50,19 @@ func (a *AgentCommand) RunQuery(ex *Execution) {
 		log.Debug("agent: Filtered nodes to run: ", filterNodes)
 		log.Debug("agent: Filtered tags to run: ", job.Tags)
 
+		//serf match regexp but we want only match full tag
+		serfFilterTags := make(map[string]string)
+		for key, val := range filterTags {
+			b := new(bytes.Buffer)
+			b.WriteString("^")
+			b.WriteString(val)
+			b.WriteString("$")
+			serfFilterTags[key] = b.String()
+		}
+
 		params = &serf.QueryParam{
 			FilterNodes: filterNodes,
-			FilterTags:  filterTags,
+			FilterTags:  serfFilterTags,
 			RequestAck:  true,
 		}
 	} else {

--- a/dkron/rpc.go
+++ b/dkron/rpc.go
@@ -86,7 +86,7 @@ func (rpcs *RPCServer) ExecutionDone(execution Execution, reply *serf.NodeRespon
 		job.ErrorCount++
 	}
 
-	if err := rpcs.agent.store.SetJob(job); err != nil {
+	if err := rpcs.agent.store.SetJob(job,nil); err != nil {
 		log.Fatal("rpc:", err)
 	}
 

--- a/dkron/rpc_test.go
+++ b/dkron/rpc_test.go
@@ -50,7 +50,7 @@ func TestRPCExecutionDone(t *testing.T) {
 		Disabled: true,
 	}
 
-	if err := store.SetJob(testJob); err != nil {
+	if err := store.SetJob(testJob,nil); err != nil {
 		t.Fatalf("error creating job: %s", err)
 	}
 

--- a/dkron/store_test.go
+++ b/dkron/store_test.go
@@ -31,7 +31,7 @@ func TestStore(t *testing.T) {
 		t.Fatal("jobs empty, expecting empty slice")
 	}
 
-	if err := store.SetJob(testJob); err != nil {
+	if err := store.SetJob(testJob,nil); err != nil {
 		t.Fatalf("error creating job: %s", err)
 	}
 


### PR DESCRIPTION
Fix issue #279 

A way to reproduce the bug was
1 °) POST parentjob.json
2°) POST childjob.json

Here dependentJob is successfully fullfilled

3°) POST parentjob.json (in order to update it)

dependentJobs have been wiped
 
Now setJob function also takes previousJob as arg (eventually niled) and if not niled copy dependent jobs (if present)