### PR TITLE
Add retries for rpcconfig query timeouts

### DIFF
--- a/dkron/queries.go
+++ b/dkron/queries.go
@@ -150,6 +150,7 @@ func (a *AgentCommand) schedulerRestartQuery(leaderName string) {
 // Broadcast a query to get the RPC config of one dkron_server, any that could
 // attend later RPC calls.
 func (a *AgentCommand) queryRPCConfig() ([]byte, error) {
+queryConfigStart:
 	nodeName := a.selectServer().Name
 
 	params := &serf.QueryParam{
@@ -196,6 +197,13 @@ func (a *AgentCommand) queryRPCConfig() ([]byte, error) {
 	log.WithFields(logrus.Fields{
 		"query": QueryRPCConfig,
 	}).Debug("proc: Done receiving acks and responses")
+
+	if rpcAddr == nil {
+		log.WithFields(logrus.Fields{
+			"query": QueryRPCConfig,
+		}).Debug("proc: Failed to receive a config response, retrying")
+		goto queryConfigStart
+	}
 
 	return rpcAddr, nil
 }


### PR DESCRIPTION
This should fix an issue that I have had very similar
to #237 where tasks would fail to register their results
because they couldn't get the RPC address of a server. This
coupled with a job config of "concurrency": "forbid" meant
jobs would stop indefinitely.

The path where rpcAddr is nil from queryRPCConfig() is
a path dkron should never return because it means that
results are never recorded.