### PR TITLE
Cleanup some documentation on the dkron package

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -33,7 +33,7 @@ const (
 var (
 	expNode = expvar.NewString("node")
 
-	// Error thrown on obtained leader from store is not found in member list
+	// ErrLeaderNotFound is returned when obtained leader from store is not found in member list
 	ErrLeaderNotFound = errors.New("No member leader found in member list")
 
 	defaultLeaderTTL = 20 * time.Second
@@ -60,6 +60,7 @@ type AgentCommand struct {
 	ready     bool
 }
 
+// Help returns agent command usage to the CLI.
 func (a *AgentCommand) Help() string {
 	helpText := `
 Usage: dkron agent [options]
@@ -281,6 +282,7 @@ func (a *AgentCommand) setupSerf() *serf.Serf {
 	return serf
 }
 
+// Config returns the agent's config.
 func (a *AgentCommand) Config() *Config {
 	return a.config
 }
@@ -299,6 +301,10 @@ func UnmarshalTags(tags []string) (map[string]string, error) {
 	return result, nil
 }
 
+// Run will execute the main functions of the agent command.
+// This includes the main eventloop and starting the server if enabled.
+//
+// The returned value is the exit code.
 func (a *AgentCommand) Run(args []string) int {
 	a.config = NewConfig(args, a.Version)
 	if a.serf = a.setupSerf(); a.serf == nil {
@@ -314,14 +320,15 @@ func (a *AgentCommand) Run(args []string) int {
 	expNode.Set(a.config.NodeName)
 
 	if a.config.Server {
-		a.StartServer()
+		a.startServer()
 	}
 	go a.eventLoop()
 	a.ready = true
 	return a.handleSignals()
 }
 
-func (a *AgentCommand) StartServer() {
+// startServer handles all necessary startup functions for a server agent
+func (a *AgentCommand) startServer() {
 	a.store = NewStore(a.config.Backend, a.config.BackendMachines, a, a.config.Keyspace)
 	a.sched = NewScheduler()
 
@@ -393,19 +400,19 @@ WAIT:
 // handleReload is invoked when we should reload our configs, e.g. SIGHUP
 func (a *AgentCommand) handleReload() {
 	a.Ui.Output("Reloading configuration...")
-	newConf := ReadConfig(a.Version)
+	newConf := readConfig(a.Version)
 	if newConf == nil {
 		a.Ui.Error(fmt.Sprintf("Failed to reload configs"))
 		return
-	} else {
-		a.config = newConf
 	}
+	a.config = newConf
 
 	// Reset serf tags
 	a.serf.SetTags(a.config.Tags)
 	//Config reloading will also reload Notification settings
 }
 
+// Synopsis returns the purpose of the command for the CLI
 func (a *AgentCommand) Synopsis() string {
 	return "Run dkron"
 }
@@ -477,6 +484,8 @@ func (a *AgentCommand) listServers() []serf.Member {
 	return members
 }
 
+// GetBindIP returns the IP address that the agent is bound to.
+// This could be different than the originally configured address.
 func (a *AgentCommand) GetBindIP() (string, error) {
 	bindIP, _, err := a.config.AddrParts(a.config.BindAddr)
 	return bindIP, err
@@ -545,8 +554,8 @@ func (a *AgentCommand) eventLoop() {
 						}
 					}()
 
-					exJson, _ := json.Marshal(ex)
-					query.Respond(exJson)
+					exJSON, _ := json.Marshal(ex)
+					query.Respond(exJSON)
 				}
 
 				if query.Name == QueryRPCConfig && a.config.Server {
@@ -583,8 +592,7 @@ func (a *AgentCommand) schedule() {
 // Join asks the Serf instance to join. See the Serf.Join function.
 func (a *AgentCommand) join(addrs []string, replay bool) (n int, err error) {
 	log.Infof("agent: joining: %v replay: %v", addrs, replay)
-	ignoreOld := !replay
-	n, err = a.serf.Join(addrs, ignoreOld)
+	n, err = a.serf.Join(addrs, !replay)
 	if n > 0 {
 		log.Infof("agent: joined: %d nodes", n)
 	}
@@ -651,7 +659,7 @@ func (a *AgentCommand) setExecution(payload []byte) *Execution {
 // of the current member.
 // in marathon, it would return the host's IP and advertise RPC port
 func (a *AgentCommand) getRPCAddr() string {
-	bindIp := a.serf.LocalMember().Addr
+	bindIP := a.serf.LocalMember().Addr
 
-	return fmt.Sprintf("%s:%d", bindIp, a.config.AdvertiseRPCPort)
+	return fmt.Sprintf("%s:%d", bindIP, a.config.AdvertiseRPCPort)
 }

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Config stores all configuration options for the dkron package.
 type Config struct {
 	NodeName              string
 	BindAddr              string
@@ -61,7 +62,7 @@ type Config struct {
 	StatsdAddr    string
 }
 
-// This is the default port that we use for Serf communication
+// DefaultBindPort is the default port that dkron will use for Serf communication
 const DefaultBindPort int = 8946
 
 func init() {
@@ -73,10 +74,10 @@ func init() {
 	viper.AutomaticEnv()
 }
 
-// readConfig is responsible for setup of our configuration using
-// the command line and any file configs
+// NewConfig creates a Config object and will set up the dkron configuration using
+// the command line and any file configs.
 func NewConfig(args []string, version string) *Config {
-	cmdFlags := ConfigFlagSet()
+	cmdFlags := configFlagSet()
 
 	ignore := args[len(args)-1] == "ignore"
 	if ignore {
@@ -105,10 +106,11 @@ func NewConfig(args []string, version string) *Config {
 		}
 	})
 
-	return ReadConfig(version)
+	return readConfig(version)
 }
 
-func ConfigFlagSet() *flag.FlagSet {
+// configFlagSet creates all of our configuration flags.
+func configFlagSet() *flag.FlagSet {
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Panic(err)
@@ -160,8 +162,8 @@ func ConfigFlagSet() *flag.FlagSet {
 	return cmdFlags
 }
 
-// ReadConfig from file and create the actual config object.
-func ReadConfig(version string) *Config {
+// readConfig from file and create the actual config object.
+func readConfig(version string) *Config {
 	err := viper.ReadInConfig() // Find and read the config file
 	if err != nil {             // Handle errors reading the config file
 		logrus.WithError(err).Info("No valid config found: Applying default values.")
@@ -249,7 +251,7 @@ START:
 	return addr.IP.String(), addr.Port, nil
 }
 
-// Networkinterface is used to get the associated network
+// NetworkInterface is used to get the associated network
 // interface from the configured value
 func (c *Config) NetworkInterface() (*net.Interface, error) {
 	if c.Interface == "" {

--- a/dkron/config_test.go
+++ b/dkron/config_test.go
@@ -18,12 +18,12 @@ func TestReadConfigTags(t *testing.T) {
 		}
 	}`)
 	viper.ReadConfig(bytes.NewBuffer(jsonConfig))
-	config := ReadConfig("0.1.0")
+	config := readConfig("0.1.0")
 	t.Log(config.Tags)
 	assert.Equal(t, "bar", config.Tags["foo"])
 
 	viper.Set("tag", []string{"monthy=python"})
-	config = ReadConfig("0.1.0")
+	config = readConfig("0.1.0")
 	assert.NotContains(t, config.Tags, "foo")
 	assert.Contains(t, config.Tags, "monthy")
 	assert.Equal(t, "python", config.Tags["monthy"])

--- a/dkron/dashboard.go
+++ b/dkron/dashboard.go
@@ -48,7 +48,8 @@ func newCommonDashboardData(a *AgentCommand, nodeName, path string) *commonDashb
 	}
 }
 
-func (a *AgentCommand) DashboardRoutes(r *gin.RouterGroup) {
+// dashboardRoutes registers dashboard specific routes on the gin RouterGroup.
+func (a *AgentCommand) dashboardRoutes(r *gin.RouterGroup) {
 	r.GET("/static/*asset", servePublic)
 
 	dashboard := r.Group("/" + dashboardPathPrefix)
@@ -113,7 +114,7 @@ func mustLoadTemplate(path string) []byte {
 	return tmpl
 }
 
-func CreateMyRender() multitemplate.Render {
+func createMyRender() multitemplate.Render {
 	r := multitemplate.New()
 
 	status := mustLoadTemplate(tmplPath + "/status.html.tmpl")

--- a/dkron/execution.go
+++ b/dkron/execution.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// Execution type holds all of the details of a specific Execution.
 type Execution struct {
 	// Name of the job this executions refers to.
 	JobName string `json:"job_name,omitempty"`
@@ -31,7 +32,7 @@ type Execution struct {
 	Attempt uint `json:"attempt,omitempty"`
 }
 
-// Init a new execution
+// NewExecution creates a new execution.
 func NewExecution(jobName string) *Execution {
 	return &Execution{
 		JobName: jobName,
@@ -40,11 +41,13 @@ func NewExecution(jobName string) *Execution {
 	}
 }
 
-// Used to enerate the execution Id
+// Key wil generate the execution Id for an execution.
 func (e *Execution) Key() string {
 	return fmt.Sprintf("%d-%s", e.StartedAt.UnixNano(), e.NodeName)
 }
 
+// ExecList stores a slice of Executions.
+// This slice can be sorted to provide a time ordered slice of Executions.
 type ExecList []*Execution
 
 func (el ExecList) Len() int {

--- a/dkron/execution_processor.go
+++ b/dkron/execution_processor.go
@@ -1,12 +1,13 @@
 package dkron
 
-// Execution processor plugins must implement this interface
+// ExecutionProcessor is an interface that wraps the Process method.
+// Plugins must implement this interface.
 type ExecutionProcessor interface {
 	// Main plugin method, will be called when an execution is done.
 	Process(args *ExecutionProcessorArgs) Execution
 }
 
-// Arguments for calling an execution processor
+// ExecutionProcessorArgs holds the Execution and PluginConfig for an ExecutionProcessor.
 type ExecutionProcessorArgs struct {
 	// The execution to pass to the processor
 	Execution Execution
@@ -14,5 +15,5 @@ type ExecutionProcessorArgs struct {
 	Config PluginConfig
 }
 
-// Represents a plgin config data structure
+// PluginConfig holds a map of the plugin configuration data structure.
 type PluginConfig map[string]interface{}

--- a/dkron/flag_slice_value.go
+++ b/dkron/flag_slice_value.go
@@ -10,6 +10,7 @@ func (s *AppendSliceValue) String() string {
 	return strings.Join(*s, ",")
 }
 
+// Set allows setting a flag value with multiple values in a slice.
 func (s *AppendSliceValue) Set(value string) error {
 	if *s == nil {
 		*s = make([]string, 0, 1)

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -11,24 +11,37 @@ import (
 )
 
 const (
+	// Success is status of a job whose last run was a success.
 	Success = iota
+	// Running is status of a job whose last run has not finished.
 	Running
+	// Failed is status of a job whose last run was not successful on any nodes.
 	Failed
+	// PartialyFailed is status of a job whose last run was successful on only some nodes.
 	PartialyFailed
 
-	ConcurrencyAllow  = "allow"
+	// ConcurrencyAllow allows a job to execute concurrency.
+	ConcurrencyAllow = "allow"
+	// ConcurrencyForbid forbids a job from executing concurrency.
 	ConcurrencyForbid = "forbid"
 )
 
 var (
+	// ErrParentJobNotFound is returned when the parent job is not found.
 	ErrParentJobNotFound = errors.New("Specified parent job not found")
-	ErrNoAgent           = errors.New("No agent defined")
-	ErrSameParent        = errors.New("The job can not have itself as parent")
-	ErrNoParent          = errors.New("The job doens't have a parent job set")
-	ErrNoCommand         = errors.New("Unespecified command for job")
-	ErrWrongConcurrency  = errors.New("Wrong concurrency policy value, use: allow/forbid")
+	// ErrNoAgent is returned when the job's agent is nil.
+	ErrNoAgent = errors.New("No agent defined")
+	// ErrSameParent is returned when the job's parent is itself.
+	ErrSameParent = errors.New("The job can not have itself as parent")
+	// ErrNoParent is returned when the job has no parent.
+	ErrNoParent = errors.New("The job doens't have a parent job set")
+	// ErrNoCommand is returned when attempting to store a job that has no command.
+	ErrNoCommand = errors.New("Unespecified command for job")
+	// ErrWrongConcurrency is returned when Concurrency is set to a non existing setting.
+	ErrWrongConcurrency = errors.New("Wrong concurrency policy value, use: allow/forbid")
 )
 
+// Job descibes a scheduled Job.
 type Job struct {
 	// Job name. Must be unique, acts as the id.
 	Name string `json:"name"`
@@ -120,8 +133,7 @@ func (j *Job) String() string {
 	return fmt.Sprintf("\"Job: %s, scheduled at: %s, tags:%v\"", j.Name, j.Schedule, j.Tags)
 }
 
-// Return the status of a job
-// Wherever it's running, succeded or failed
+// Status returns the status of a job whether it's running, succeded or failed
 func (j *Job) Status() int {
 	// Maybe we are testing
 	if j.Agent == nil {
@@ -157,7 +169,7 @@ func (j *Job) Status() int {
 	return status
 }
 
-// Get the parent job of a job
+// GetParent returns the parent job of a job
 func (j *Job) GetParent() (*Job, error) {
 	// Maybe we are testing
 	if j.Agent == nil {
@@ -176,9 +188,9 @@ func (j *Job) GetParent() (*Job, error) {
 	if err != nil {
 		if err == store.ErrKeyNotFound {
 			return nil, ErrParentJobNotFound
-		} else {
-			return nil, err
 		}
+		return nil, err
+
 	}
 
 	return parentJob, nil

--- a/dkron/keygen.go
+++ b/dkron/keygen.go
@@ -4,8 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"github.com/mitchellh/cli"
 	"strings"
+
+	"github.com/mitchellh/cli"
 )
 
 // KeygenCommand is a Command implementation that generates an encryption
@@ -14,6 +15,7 @@ type KeygenCommand struct {
 	Ui cli.Ui
 }
 
+// Run is the main entrypoint for the keygen command
 func (c *KeygenCommand) Run(_ []string) int {
 	key := make([]byte, 16)
 	n, err := rand.Reader.Read(key)
@@ -30,10 +32,12 @@ func (c *KeygenCommand) Run(_ []string) int {
 	return 0
 }
 
+// Synopsis returns the purpose fo the KeygenCommand for the CLI help text.
 func (c *KeygenCommand) Synopsis() string {
 	return "Generates a new encryption key"
 }
 
+// Help returns the usage text for the CLI.
 func (c *KeygenCommand) Help() string {
 	helpText := `
 Usage: dkron keygen

--- a/dkron/log.go
+++ b/dkron/log.go
@@ -7,6 +7,7 @@ import (
 
 var log = logrus.NewEntry(logrus.New())
 
+// InitLogger creates the logger instance
 func InitLogger(logLevel string, node string) {
 	formattedLogger := logrus.New()
 	formattedLogger.Formatter = &logrus.TextFormatter{FullTimestamp: true}


### PR DESCRIPTION
This should help clarify some on the purpose of exported functions,
constants, errors, types, and interfaces. I changed some functions
to be unexported because they should not be modified outside the
dkron package. I hope to clean up some more in the future when
I can find some more time.