### PR TITLE
Remove Config dependency on AgentCommand

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -300,7 +300,7 @@ func UnmarshalTags(tags []string) (map[string]string, error) {
 }
 
 func (a *AgentCommand) Run(args []string) int {
-	a.config = NewConfig(args, a)
+	a.config = NewConfig(args, a.Version)
 	if a.serf = a.setupSerf(); a.serf == nil {
 		log.Fatal("agent: Can not setup serf")
 	}
@@ -393,7 +393,7 @@ WAIT:
 // handleReload is invoked when we should reload our configs, e.g. SIGHUP
 func (a *AgentCommand) handleReload() {
 	a.Ui.Output("Reloading configuration...")
-	newConf := ReadConfig(a)
+	newConf := ReadConfig(a.Version)
 	if newConf == nil {
 		a.Ui.Error(fmt.Sprintf("Failed to reload configs"))
 		return

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -75,7 +75,7 @@ func init() {
 
 // readConfig is responsible for setup of our configuration using
 // the command line and any file configs
-func NewConfig(args []string, agent *AgentCommand) *Config {
+func NewConfig(args []string, version string) *Config {
 	cmdFlags := ConfigFlagSet()
 
 	ignore := args[len(args)-1] == "ignore"
@@ -105,7 +105,7 @@ func NewConfig(args []string, agent *AgentCommand) *Config {
 		}
 	})
 
-	return ReadConfig(agent)
+	return ReadConfig(version)
 }
 
 func ConfigFlagSet() *flag.FlagSet {
@@ -161,7 +161,7 @@ func ConfigFlagSet() *flag.FlagSet {
 }
 
 // ReadConfig from file and create the actual config object.
-func ReadConfig(agent *AgentCommand) *Config {
+func ReadConfig(version string) *Config {
 	err := viper.ReadInConfig() // Find and read the config file
 	if err != nil {             // Handle errors reading the config file
 		logrus.WithError(err).Info("No valid config found: Applying default values.")
@@ -185,7 +185,7 @@ func ReadConfig(agent *AgentCommand) *Config {
 	if server {
 		tags["dkron_server"] = "true"
 	}
-	tags["dkron_version"] = agent.Version
+	tags["dkron_version"] = version
 
 	InitLogger(viper.GetString("log_level"), nodeName)
 

--- a/dkron/config_test.go
+++ b/dkron/config_test.go
@@ -6,19 +6,9 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/mitchellh/cli"
 )
 
 func TestReadConfigTags(t *testing.T) {
-	shutdownCh := make(chan struct{})
-	defer close(shutdownCh)
-
-	ui := new(cli.MockUi)
-	a := &AgentCommand{
-		Ui:         ui,
-		ShutdownCh: shutdownCh,
-	}
 
 	viper.Reset()
 	viper.SetConfigType("json")
@@ -28,17 +18,17 @@ func TestReadConfigTags(t *testing.T) {
 		}
 	}`)
 	viper.ReadConfig(bytes.NewBuffer(jsonConfig))
-	config := ReadConfig(a)
+	config := ReadConfig("0.1.0")
 	t.Log(config.Tags)
 	assert.Equal(t, "bar", config.Tags["foo"])
 
 	viper.Set("tag", []string{"monthy=python"})
-	config = ReadConfig(a)
+	config = ReadConfig("0.1.0")
 	assert.NotContains(t, config.Tags, "foo")
 	assert.Contains(t, config.Tags, "monthy")
 	assert.Equal(t, "python", config.Tags["monthy"])
 
-	config = NewConfig([]string{"-tag", "t1=v1", "-tag", "t2=v2"}, a)
+	config = NewConfig([]string{"-tag", "t1=v1", "-tag", "t2=v2"}, "0.1.0")
 	assert.Equal(t, "v1", config.Tags["t1"])
 	assert.Equal(t, "v2", config.Tags["t2"])
 }


### PR DESCRIPTION
The config was only using the version parameter
of AgentCommand. This simplifies config to not need
any external types and makes unit tests a bit cleaner.