### PR TITLE
Remove api understanding of job dependencies

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -142,27 +142,8 @@ func (h *HTTPTransport) jobCreateOrUpdateHandler(c *gin.Context) {
 	}
 	c.BindJSON(&job)
 
-	// Get if the requested job already exist
-	ej, err := h.agent.Store.GetJob(job.Name)
-	if err != nil && err != store.ErrKeyNotFound {
-		c.AbortWithError(422, err)
-		return
-	}
-
-	// If it's an existing job, lock it
-	if ej != nil {
-		ej.Lock()
-		defer ej.Unlock()
-	}
-
 	// Save the job to the store
-	if err = h.agent.Store.SetJob(&job, ej); err != nil {
-		c.AbortWithError(422, err)
-		return
-	}
-
-	// Save the job parent
-	if err = h.agent.Store.SetJobDependencyTree(&job, ej); err != nil {
+	if err := h.agent.Store.SetJob(&job, true); err != nil {
 		c.AbortWithError(422, err)
 		return
 	}

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -19,6 +19,7 @@ func setupAPITest(t *testing.T) (a *Agent) {
 		"-node-name", "test",
 		"-server",
 		"-log-level", logLevel,
+		"-keyspace", "dkron-test",
 	}
 
 	c := NewConfig(args)
@@ -32,6 +33,9 @@ func setupAPITest(t *testing.T) (a *Agent) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	time.Sleep(1 * time.Second)
+
+	// clean up the keyspace to ensure clean runs
+	a.Store.Client.DeleteTree("dkron-test")
 
 	return
 }

--- a/dkron/job_test.go
+++ b/dkron/job_test.go
@@ -16,7 +16,7 @@ func TestJobGetParent(t *testing.T) {
 
 	// Cleanup everything
 	err := store.Client.DeleteTree("dkron-test")
-	if err != s.ErrKeyNotFound {
+	if err != nil && err != s.ErrKeyNotFound {
 		t.Logf("error cleaning up: %s", err)
 	}
 
@@ -26,7 +26,7 @@ func TestJobGetParent(t *testing.T) {
 		Schedule: "@every 2s",
 	}
 
-	if err := store.SetJob(parentTestJob, nil); err != nil {
+	if err := store.SetJob(parentTestJob, true); err != nil {
 		t.Fatalf("error creating job: %s", err)
 	}
 
@@ -36,10 +36,7 @@ func TestJobGetParent(t *testing.T) {
 		ParentJob: "parent_test",
 	}
 
-	err = store.SetJob(dependentTestJob, nil)
-	assert.NoError(t, err)
-
-	err = store.SetJobDependencyTree(dependentTestJob, nil)
+	err = store.SetJob(dependentTestJob, true)
 	assert.NoError(t, err)
 
 	parentTestJob, err = dependentTestJob.GetParent()
@@ -51,14 +48,9 @@ func TestJobGetParent(t *testing.T) {
 	assert.Equal(t, parentTestJob, ptj)
 
 	// Remove the parent job
-	ej, _ := store.GetJob(dependentTestJob.Name)
-
 	dependentTestJob.ParentJob = ""
 	dependentTestJob.Schedule = "@every 2m"
-	err = store.SetJob(dependentTestJob, nil)
-	assert.NoError(t, err)
-
-	err = store.SetJobDependencyTree(dependentTestJob, ej)
+	err = store.SetJob(dependentTestJob, true)
 	assert.NoError(t, err)
 
 	dtj, _ := store.GetJob(dependentTestJob.Name)

--- a/dkron/rpc_test.go
+++ b/dkron/rpc_test.go
@@ -43,7 +43,7 @@ func TestRPCExecutionDone(t *testing.T) {
 		Disabled: true,
 	}
 
-	if err := store.SetJob(testJob, nil); err != nil {
+	if err := store.SetJob(testJob, true); err != nil {
 		t.Fatalf("error creating job: %s", err)
 	}
 

--- a/dkron/store_test.go
+++ b/dkron/store_test.go
@@ -31,7 +31,7 @@ func TestStore(t *testing.T) {
 	}
 	assert.NotNil(t, jobs, "jobs nil, expecting empty slice")
 
-	if err := s.SetJob(testJob, nil); err != nil {
+	if err := s.SetJob(testJob, true); err != nil {
 		t.Fatalf("error creating job: %s", err)
 	}
 


### PR DESCRIPTION
This should keep the api from needing to understand
that a job can have a parent or dependent jobs. This
slightly simplifies the functions and allows SetJob on
the store to have controll over job editing.