### PR TITLE
Improve API call on create or edit jobs

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -96,7 +96,7 @@ func (a *Agent) Stop() error {
 	if err := a.serf.Leave(); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 


### PR DESCRIPTION
When creating jobs, a bunch of time is invested in sending the scheduler restart query and waiting for the response.

This sets refactor performs all store operations but runs the restart scheduler call in a new thread when a timeout is finished so it could be called multiple times and just the last one will be executed to reload jobs.

fixes #276
fixes #244