### PR TITLE
Add redis as storage backend

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,6 +27,7 @@
     "store",
     "store/consul",
     "store/etcd/v2",
+    "store/redis",
     "store/zookeeper"
   ]
   revision = "063d875e3c5fd734fa2aa12fac83829f62acfc70"
@@ -469,6 +470,19 @@
   version = "v8.18.2"
 
 [[projects]]
+  name = "gopkg.in/redis.v5"
+  packages = [
+    ".",
+    "internal",
+    "internal/consistenthash",
+    "internal/hashtag",
+    "internal/pool",
+    "internal/proto"
+  ]
+  revision = "a16aeec10ff407b1e7be6dd35797ccf5426ef0f0"
+  version = "v5.2.9"
+
+[[projects]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -477,6 +491,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f8be537631e515e6f046ce0f573c287aec8ab8631ac0b54cc018fadabab129d3"
+  inputs-digest = "a69a3d58c63953044edececa1b7759634c5372ca6aac280a48b88ae732820d9b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -52,8 +52,8 @@ Options:
                                   key/value tag pairs to the given node.
   -keyspace=dkron                 The keyspace to use. A prefix under all data is stored
                                   for this instance.
-  -backend=[etcd|consul|zk]       Backend storage to use, etcd, consul or zookeeper. The default
-                                  is etcd.
+  -backend=[etcd|consul|zk|redis] Backend storage to use, etcd, consul, zk (zookeeper) or redis.
+                                  The default is etcd.
   -backend-machine=127.0.0.1:2379 Backend storage servers addresses to connect to. This flag can be
                                   specified multiple times.
   -encrypt                        Key for encrypting network traffic.

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -9,7 +9,8 @@ import (
 	"github.com/abronan/valkeyrie"
 	"github.com/abronan/valkeyrie/store"
 	"github.com/abronan/valkeyrie/store/consul"
-	etcd "github.com/abronan/valkeyrie/store/etcd/v2"
+	"github.com/abronan/valkeyrie/store/etcd/v2"
+	"github.com/abronan/valkeyrie/store/redis"
 	"github.com/abronan/valkeyrie/store/zookeeper"
 	"github.com/victorcoder/dkron/cron"
 )
@@ -50,6 +51,7 @@ func init() {
 	etcd.Register()
 	consul.Register()
 	zookeeper.Register()
+	redis.Register()
 }
 
 func NewStore(backend string, machines []string, a *Agent, keyspace string, config *store.Config) *Store {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,18 @@ services:
       - "2181"
     hostname: node1
 
+  redis:
+    image: redis
+    ports:
+      - "6379"
+
   dkron:
     build: .
     depends_on:
       - consul
       - etcd
       - zk
+      - redis
     ports:
       - "8080"
       - "8946"
@@ -43,3 +49,5 @@ services:
     # command: scripts/entrypoint.sh agent -server -backend=etcd -backend-machine=etcd:2379 -join=dkron:8946 -log-level=debug
     # Uncomment to use zk
     # command: scripts/entrypoint.sh agent -server -backend=zk -backend-machine=zk:2181 -join=dkron:8946 -log-level=debug
+    # Uncomment to use redis
+    # command: scripts/entrypoint.sh agent -server -backend=redis -backend-machine=redis:6379 -join=dkron:8946 -log-level=debug

--- a/scripts/test-infra/dd-conf/redis.yaml
+++ b/scripts/test-infra/dd-conf/redis.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+   -   host: redis0
+       port: 6379
+       timeout: 3

--- a/scripts/test-infra/redis
+++ b/scripts/test-infra/redis
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+docker service rm redis0
+
+docker service create \
+--name redis0 \
+--network my-net \
+redis
+
+sleep 10
+
+docker service rm dkron-redis0 dkron-redis
+
+docker service create \
+--name dkron-redis0 \
+--network my-net \
+--publish 8090:8080 \
+--container-label beta="0" \
+dkron/dkron:v0.9.3 \
+agent -server -bind=0.0.0.0:8946 -backend=redis -backend-machine=redis0:6379 -join=dkron-redis0:8946 -dog-statsd-addr=dd-agent:8125 -log-level=debug
+
+sleep 5
+
+docker service create \
+--name dkron-redis \
+--network my-net \
+--replicas 5 \
+--publish 8091:8080 \
+--container-label beta="0" \
+dkron/dkron:v0.9.3 \
+agent -server -bind=0.0.0.0:8946 -backend=redis -backend-machine=redis0:6379 -join=dkron-redis0:8946 -dog-statsd-addr=dd-agent:8125 -log-level=debug

--- a/website/content/basics/configuration.md
+++ b/website/content/basics/configuration.md
@@ -18,7 +18,7 @@ Settings for dkron can be specified in three ways: Using a `config/dkron.json` c
 
 * `-http-addr` - The address where the web UI will be binded. By default `:8080`
 
-* `-backend` - Backend storage to use, etcd, consul or zk (zookeeper). The default is etcd.
+* `-backend` - Backend storage to use, etcd, consul, zk (zookeeper) or redis. The default is etcd.
 
 * `-backend-machine` - Backend storage servers addresses to connect to. This flag can be specified multiple times. By default `127.0.0.1:2379`
 


### PR DESCRIPTION
Hello guys,

First of all, thank you for the great software. We are thinking of giving a try ;)

One little issue we have is we don't wanna extend our infra having etcd or consul.
We have Redis running ad it would be nice to utilize it for dkron as well.

We noticed that `github.com/abronan/valkeyrie` has redis support.
And it works perfectly for us.

What do you think?
Thank you
