### PR TITLE
Try to fix execution done missing

### DIFF
--- a/dkron/execution.go
+++ b/dkron/execution.go
@@ -2,6 +2,7 @@ package dkron
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -44,6 +45,10 @@ func NewExecution(jobName string) *Execution {
 // Key wil generate the execution Id for an execution.
 func (e *Execution) Key() string {
 	return fmt.Sprintf("%d-%s", e.StartedAt.UnixNano(), e.NodeName)
+}
+
+func (e *Execution) GetGroup() string {
+	return strconv.FormatInt(e.Group, 10)
 }
 
 // ExecList stores a slice of Executions.

--- a/dkron/invoke.go
+++ b/dkron/invoke.go
@@ -43,7 +43,7 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 	// Check if executor is exists
 	if executor, ok := a.ExecutorPlugins[jex]; ok {
 		log.WithField("plugin", jex).Debug("invoke: calling executor plugin")
-		runningExecutions[execution.Key()] = execution
+		runningExecutions[execution.GetGroup()] = execution
 		out, err := executor.Execute(&ExecuteRequest{
 			JobName: job.Name,
 			Config:  exc,
@@ -70,7 +70,7 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 		return err
 	}
 
-	delete(runningExecutions, execution.Key())
+	delete(runningExecutions, execution.GetGroup())
 	rc := &RPCClient{ServerAddr: string(rpcServer)}
 	return rc.callExecutionDone(execution)
 }

--- a/dkron/invoke.go
+++ b/dkron/invoke.go
@@ -43,6 +43,7 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 	// Check if executor is exists
 	if executor, ok := a.ExecutorPlugins[jex]; ok {
 		log.WithField("plugin", jex).Debug("invoke: calling executor plugin")
+		runningExecutions[execution.Key()] = execution
 		out, err := executor.Execute(&ExecuteRequest{
 			JobName: job.Name,
 			Config:  exc,
@@ -57,7 +58,7 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 
 		output.Write(out)
 	} else {
-		log.Errorf("invoke: Specified executor %s is not present", executor)
+		log.WithField("executor", executor).Error("invoke: Specified executor is not present")
 	}
 
 	execution.FinishedAt = time.Now()
@@ -69,6 +70,7 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 		return err
 	}
 
+	delete(runningExecutions, execution.Key())
 	rc := &RPCClient{ServerAddr: string(rpcServer)}
 	return rc.callExecutionDone(execution)
 }

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -240,7 +240,9 @@ func (j *Job) Unlock() error {
 }
 
 func (j *Job) isRunnable() bool {
-	j.Agent.RefreshJobStatus(j.Name)
+	if j.Concurrency == ConcurrencyForbid {
+		j.Agent.RefreshJobStatus(j.Name)
+	}
 	status := j.Status()
 
 	if status == Running {

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -240,6 +240,7 @@ func (j *Job) Unlock() error {
 }
 
 func (j *Job) isRunnable() bool {
+	j.Agent.RefreshJobStatus(j.Name)
 	status := j.Status()
 
 	if status == Running {


### PR DESCRIPTION
As #349 describes, a job with forbidden concurrency doesn't execute again if the target node is restarted.

This PR tries to sove it by implementing a mechanism that asks the running nodes about the job status before checking if the job finished and before running the job.

fixes #349