### PR TITLE
Fix windows plugins for v0.10

### DIFF
--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -60,9 +60,9 @@ func (p *Plugins) DiscoverPlugins() error {
 	}
 
 	for _, file := range processors {
-		// Look for foo-bar-baz. The plugin name is "baz"
-		parts := strings.SplitN(file, "-", 3)
-		if len(parts) != 3 {
+
+		pluginName, ok := getPluginName(file)
+		if !ok {
 			continue
 		}
 
@@ -70,13 +70,13 @@ func (p *Plugins) DiscoverPlugins() error {
 		if err != nil {
 			return err
 		}
-		p.Processors[parts[2]] = raw.(dkron.ExecutionProcessor)
+		p.Processors[pluginName] = raw.(dkron.ExecutionProcessor)
 	}
 
 	for _, file := range executors {
-		// Look for foo-bar-baz. The plugin name is "baz"
-		parts := strings.SplitN(file, "-", 3)
-		if len(parts) != 3 {
+
+		pluginName, ok := getPluginName(file)
+		if !ok {
 			continue
 		}
 
@@ -84,10 +84,22 @@ func (p *Plugins) DiscoverPlugins() error {
 		if err != nil {
 			return err
 		}
-		p.Executors[parts[2]] = raw.(dkron.Executor)
+		p.Executors[pluginName] = raw.(dkron.Executor)
 	}
 
 	return nil
+}
+
+func getPluginName(file string) (string, bool) {
+	// Look for foo-bar-baz. The plugin name is "baz"
+	parts := strings.SplitN(file, "-", 3)
+	if len(parts) != 3 {
+		return "", false
+	}
+
+	// This cleans off the .exe for windows plugins
+	name := strings.TrimRight(parts[2], ".exe")
+	return name, true
 }
 
 func (Plugins) pluginFactory(path string, pluginType string) (interface{}, error) {

--- a/dkron/invoke.go
+++ b/dkron/invoke.go
@@ -61,7 +61,7 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 
 		output.Write(out)
 	} else {
-		log.WithField("executor", executor).Error("invoke: Specified executor is not present")
+		log.WithField("executor", jex).Error("invoke: Specified executor is not present")
 	}
 
 	execution.FinishedAt = time.Now()


### PR DESCRIPTION
These plugins were loaded off disk with an .exe
extension on windows. This was making its way into
the executor map and therefore providing a different
experience on windows vs unix/linux.

Also corrects the error message that would be logged when
this effects a user. The executor will be nil when the log
entry is written.

This should fix #370