### PR TITLE
Reflect store status in API

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -284,6 +284,9 @@ func UnmarshalTags(tags []string) (map[string]string, error) {
 func (a *Agent) StartServer() {
 	if a.Store == nil {
 		a.Store = NewStore(a.config.Backend, a.config.BackendMachines, a, a.config.Keyspace, nil)
+		if err := a.Store.Healthy(); err != nil {
+			log.WithError(err).Fatal("store: Store backend not reachable")
+		}
 	}
 
 	a.sched = NewScheduler()

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -67,12 +67,15 @@ func NewStore(backend string, machines []string, a *Agent, keyspace string, conf
 		"keyspace": keyspace,
 	}).Debug("store: Backend config")
 
-	_, err = s.List(keyspace, nil)
-	if err != store.ErrKeyNotFound && err != nil {
-		log.WithError(err).Fatal("store: Store backend not reachable")
-	}
-
 	return &Store{Client: s, agent: a, keyspace: keyspace, backend: backend}
+}
+
+func (s *Store) Healthy() error {
+	_, err := s.Client.List(s.keyspace, nil)
+	if err != store.ErrKeyNotFound && err != nil {
+		return err
+	}
+	return nil
 }
 
 // Store a job


### PR DESCRIPTION
Dkron could be running but the storage engine could be unreachable.

We introduce a new return param in the status API path / that provides that info.

backend_status Will return the backend health status encoded in HTTP codes.

At the same time the endpoint will return the corresponding HTTP code.

Closes #373 