### PR TITLE
Mitigate bug of job stuck running

### DIFF
--- a/dkron/job.go
+++ b/dkron/job.go
@@ -251,18 +251,16 @@ func (j *Job) isRunnable() bool {
 	if j.Concurrency == ConcurrencyForbid {
 		j.Agent.RefreshJobStatus(j.Name)
 	}
-	if j.Status == StatusNotSet {
-		j.Status = j.GetStatus()
-	}
+	status := j.GetStatus()
 
-	if j.Status == StatusRunning {
+	if status == StatusRunning {
 		if j.Concurrency == ConcurrencyAllow {
 			return true
 		} else if j.Concurrency == ConcurrencyForbid {
 			log.WithFields(logrus.Fields{
 				"job":         j.Name,
 				"concurrency": j.Concurrency,
-				"job_status":  j.Status,
+				"job_status":  status,
 			}).Debug("scheduler: Skipping execution")
 			return false
 		}


### PR DESCRIPTION
I'm not sure what caused this bug for me, but from the API, I
could query /v1/jobs and all statuses were "success" but when
the scheduler would try and run the job, it would log that it was
skipping execution because concurrency was forbidden and the job
was running. This updates what status is used for a job and instead of
using the status on the pointer, querries the status instead to have
a real time view of the job.