### PR TITLE
Fix retries

### DIFF
--- a/dkron/rpc.go
+++ b/dkron/rpc.go
@@ -129,13 +129,14 @@ retry:
 	Notification(rpcs.agent.config, &execution, exg, job).Send()
 
 	// Jobs that have dependent jobs are a bit more expensive because we need to call the Status() method for every execution.
-	// Check first if there's dependent jobs and then check for the job status to begin executiong dependent jobs on success.
-	if len(job.DependentJobs) > 0 && job.Status == StatusSuccess {
+	// Check first if there's dependent jobs and then check for the job status to begin execution dependent jobs on success.
+	if len(job.DependentJobs) > 0 && job.GetStatus() == StatusSuccess {
 		for _, djn := range job.DependentJobs {
 			dj, err := rpcs.agent.Store.GetJob(djn, nil)
 			if err != nil {
 				return err
 			}
+			log.WithField("job", djn).Debug("rpc: Running dependent job")
 			dj.Run()
 		}
 	}

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -399,7 +399,9 @@ func (s *Store) SetExecution(execution *Execution) (string, error) {
 
 	execs, err := s.GetExecutions(execution.JobName)
 	if err != nil {
-		log.Errorf("store: No executions found for job %s", execution.JobName)
+		log.WithError(err).
+			WithField("job", execution.JobName).
+			Error("store: Error no executions found for job")
 	}
 
 	// Delete all execution results over the limit, starting from olders
@@ -413,7 +415,9 @@ func (s *Store) SetExecution(execution *Execution) (string, error) {
 			}).Debug("store: to detele key")
 			err := s.Client.Delete(fmt.Sprintf("%s/executions/%s/%s", s.keyspace, execs[i].JobName, execs[i].Key()))
 			if err != nil {
-				log.Errorf("store: Trying to delete overflowed execution %s", execs[i].Key())
+				log.WithError(err).
+					WithField("execution", execs[i].Key()).
+					Error("store: Error trying to delete overflowed execution")
 			}
 		}
 	}


### PR DESCRIPTION
Due to a typo in refactoring job status, a missing method call prevented job retries from working properly.

Also adding some logging and doc typose fixing.

fixes #388 