### PR TITLE
fix-402

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,10 +44,10 @@ services:
     environment:
       - GODEBUG=netdns=go
     # Uncomment to use consul
-    command: scripts/entrypoint.sh agent -server -backend=consul -backend-machine=consul:8500 -join=dkron:8946 -log-level=debug
+    command: scripts/run agent -server -backend=consul -backend-machine=consul:8500 -join=dkron:8946 -log-level=debug
     # Uncomment to use etcd
-    # command: scripts/entrypoint.sh agent -server -backend=etcd -backend-machine=etcd:2379 -join=dkron:8946 -log-level=debug
+    # command: scripts/run agent -server -backend=etcd -backend-machine=etcd:2379 -join=dkron:8946 -log-level=debug
     # Uncomment to use zk
-    # command: scripts/entrypoint.sh agent -server -backend=zk -backend-machine=zk:2181 -join=dkron:8946 -log-level=debug
+    # command: scripts/run agent -server -backend=zk -backend-machine=zk:2181 -join=dkron:8946 -log-level=debug
     # Uncomment to use redis
-    # command: scripts/entrypoint.sh agent -server -backend=redis -backend-machine=redis:6379 -join=dkron:8946 -log-level=debug
+    # command: scripts/run agent -server -backend=redis -backend-machine=redis:6379 -join=dkron:8946 -log-level=debug


### PR DESCRIPTION
`entrypoint.sh` was renamed to `run` here https://github.com/victorcoder/dkron/commit/d62d0a08681ec7a5c2667b5a9e24cebe22adae6a, but wasn't updated in docker-compose.