### PR TITLE
Filter jobs by tags

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/sirupsen/logrus"
 	"github.com/abronan/valkeyrie/store"
-	gin "github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -122,7 +122,9 @@ func (h *HTTPTransport) indexHandler(c *gin.Context) {
 }
 
 func (h *HTTPTransport) jobsHandler(c *gin.Context) {
-	jobs, err := h.agent.Store.GetJobs(&JobOptions{ComputeStatus: true})
+	jobTags := c.QueryMap("tags")
+
+	jobs, err := h.agent.Store.GetJobs(&JobOptions{ComputeStatus: true, Tags: jobTags})
 	if err != nil {
 		log.WithError(err).Error("api: Unable to get jobs, store not reachable.")
 		return

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/abronan/valkeyrie/store"
+	"github.com/sirupsen/logrus"
 	"github.com/victorcoder/dkron/proto"
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,10 +44,10 @@ services:
     environment:
       - GODEBUG=netdns=go
     # Uncomment to use consul
-    command: scripts/run agent -server -backend=consul -backend-machine=consul:8500 -join=dkron:8946 -log-level=debug
+    command: scripts/run agent --server --backend=consul --backend-machine=consul:8500 --join=dkron:8946 --log-level=debug
     # Uncomment to use etcd
-    # command: scripts/run agent -server -backend=etcd -backend-machine=etcd:2379 -join=dkron:8946 -log-level=debug
+    # command: scripts/run agent --server --backend=etcd --backend-machine=etcd:2379 --join=dkron:8946 --log-level=debug
     # Uncomment to use zk
-    # command: scripts/run agent -server -backend=zk -backend-machine=zk:2181 -join=dkron:8946 -log-level=debug
+    # command: scripts/run agent --server --backend=zk --backend-machine=zk:2181 --join=dkron:8946 --log-level=debug
     # Uncomment to use redis
-    # command: scripts/run agent -server -backend=redis -backend-machine=redis:6379 -join=dkron:8946 -log-level=debug
+    # command: scripts/run agent --server --backend=redis --backend-machine=redis:6379 --join=dkron:8946 --log-level=debug

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/gin-contrib/multitemplate v0.0.0-20170922032617-bbc6daf6024b
 	github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7 // indirect
 	github.com/gin-gonic/autotls v0.0.0-20180426091246-be87bd5ef97b // indirect
-	github.com/gin-gonic/gin v0.0.0-20170702092826-d459835d2b07
+	github.com/gin-gonic/gin v1.3.0
 	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 // indirect
@@ -88,6 +88,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/jordan-wright/email v0.0.0-20180115032944-94ae17dedda2
 	github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62 // indirect
+	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
@@ -105,6 +106,8 @@ require (
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20171017171808-06020f85339e // indirect
 	github.com/mitchellh/reflectwalk v0.0.0-20170726202117-63d60e9d0dbc // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nicolai86/scaleway-sdk v1.11.1 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/gin-gonic/autotls v0.0.0-20180426091246-be87bd5ef97b h1:dm/NYytoj7p8J
 github.com/gin-gonic/autotls v0.0.0-20180426091246-be87bd5ef97b/go.mod h1:vwfeXwKgEIWq63oVfwaBjoByS4dZzYbHHROHjV4IjNY=
 github.com/gin-gonic/gin v0.0.0-20170702092826-d459835d2b07 h1:cZPJWzd2oNeoS0oJM2TlN9rl0OnCgUr10gC8Q4mH+6M=
 github.com/gin-gonic/gin v0.0.0-20170702092826-d459835d2b07/go.mod h1:7cKuhb5qV2ggCFctp2fJQ+ErvciLZrIeoOSOm6mUr7Y=
+github.com/gin-gonic/gin v1.3.0 h1:kCmZyPklC0gVdL728E6Aj20uYBJV93nj/TkwBTKhFbs=
+github.com/gin-gonic/gin v1.3.0/go.mod h1:7cKuhb5qV2ggCFctp2fJQ+ErvciLZrIeoOSOm6mUr7Y=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -174,6 +176,8 @@ github.com/jordan-wright/email v0.0.0-20180115032944-94ae17dedda2 h1:BkuA0hfZuy4
 github.com/jordan-wright/email v0.0.0-20180115032944-94ae17dedda2/go.mod h1:1c7szIrayyPPB/987hsnvNzLushdWf4o/79s3P08L8A=
 github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62 h1:JHCT6xuyPUrbbgAPE/3dqlvUKzRHMNuTBKKUb6OeR/k=
 github.com/joyent/triton-go v0.0.0-20180628001255-830d2b111e62/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
+github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
+github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1 h1:PJPDf8OUfOK1bb/NeTKd4f1QXZItOX389VN3B6qC8ro=
 github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
@@ -213,6 +217,10 @@ github.com/mitchellh/mapstructure v0.0.0-20171017171808-06020f85339e h1:PtGHLB3C
 github.com/mitchellh/mapstructure v0.0.0-20171017171808-06020f85339e/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v0.0.0-20170726202117-63d60e9d0dbc h1:gqYjvctjtX4GHzgfutJxZpvZ7XhGwQLGR5BASwhpO2o=
 github.com/mitchellh/reflectwalk v0.0.0-20170726202117-63d60e9d0dbc/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
+github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/nicolai86/scaleway-sdk v1.11.1 h1:iO97OP7oKcwQEHoX6RwcuKfw8PLKkjXLAsFNyumdh3M=
 github.com/nicolai86/scaleway-sdk v1.11.1/go.mod h1:TLb2Sg7HQcgGdloNxkrmtgDNR9uVYF3lfdFIN4Ro6Sk=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=

--- a/website/content/usage/api.md
+++ b/website/content/usage/api.md
@@ -82,6 +82,14 @@ json :
 List jobs.
 
 
+#### Parameters
+
+|Type|Name|Description|Schema|
+|---|---|---|---|
+|**query**|**tags**  <br>*optional*|Filter jobs by tags. Works as a logical and.|< string, string > map|
+
+
+
 #### Responses
 
 |HTTP Code|Description|Schema|
@@ -98,7 +106,7 @@ List jobs.
 
 ##### Request path
 ```
-/jobs
+/jobs?tags[foo]=val1&tags[bar]=val2
 ```
 
 


### PR DESCRIPTION
Hello guys, 

let me introduce this little change which could be useful for somebody else.

From now on we can assign labels to the jobs. And query (`GET /jobs`) them with labels filter. This change could be useful for the users who have to build UI and display background jobs on their own. One of the use case when you have a different kind of jobs like the system jobs and some application related and you don't want the app to see the jobs not assigned to it.

Exactly our case is that we have 3 types of jobs and 3 different UIs to display the jobs and their status. All jobs should now know about each other. Moreover, we have that 3 UI build for 12 countries. Which lead to 36 UIs. Before that change, we used prefixes like `country-app_name-actual_name_of_the_cron` and it's getting annoying now.

Feel free to comment and accept ;) 

Good luck

-----
UPDATE: 2018-08-29

No more labels, use tags to filter jobs.