### PR TITLE
add support for etcdv3

### DIFF
--- a/dkron/store.go
+++ b/dkron/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/abronan/valkeyrie/store"
 	"github.com/abronan/valkeyrie/store/consul"
 	"github.com/abronan/valkeyrie/store/etcd/v2"
+	"github.com/abronan/valkeyrie/store/etcd/v3"
 	"github.com/abronan/valkeyrie/store/redis"
 	"github.com/abronan/valkeyrie/store/zookeeper"
 	"github.com/sirupsen/logrus"
@@ -50,6 +51,7 @@ type JobOptions struct {
 
 func init() {
 	etcd.Register()
+	etcdv3.Register()
 	consul.Register()
 	zookeeper.Register()
 	redis.Register()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
     command: scripts/run agent --server --backend=consul --backend-machine=consul:8500 --join=dkron:8946 --log-level=debug
     # Uncomment to use etcd
     # command: scripts/run agent --server --backend=etcd --backend-machine=etcd:2379 --join=dkron:8946 --log-level=debug
+    # Uncomment to use etcdv3
+    # command: scripts/run agent --server --backend=etcdv3 --backend-machine=etcd:2379 --join=dkron:8946 --log-level=debug
     # Uncomment to use zk
     # command: scripts/run agent --server --backend=zk --backend-machine=zk:2181 --join=dkron:8946 --log-level=debug
     # Uncomment to use redis

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	golang.org/x/text v0.0.0-20171013141220-c01e4764d870 // indirect
 	google.golang.org/appengine v1.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20171002232614-f676e0f3ac63 // indirect
-	google.golang.org/grpc v1.13.0
+	google.golang.org/grpc v1.5.0
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRS
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20171002232614-f676e0f3ac63 h1:yNBw5bwywOTguAu+h6SkCUaWdEZ7ZXgfiwb2YTN1eQw=
 google.golang.org/genproto v0.0.0-20171002232614-f676e0f3ac63/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/grpc v1.5.0 h1:Ji47YA6K9qlzSt3Tu0EK38f3YmF/n8AoCx4REzOntu8=
+google.golang.org/grpc v1.5.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.13.0 h1:bHIbVsCwmvbArgCJmLdgOdHFXlKqTOVjbibbS19cXHc=
 google.golang.org/grpc v1.13.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=

--- a/scripts/test-infra/dd-conf/etcdv3.yaml
+++ b/scripts/test-infra/dd-conf/etcdv3.yaml
@@ -1,0 +1,7 @@
+init_config:
+
+instances:
+# url, the API endpoint of your etcd instance
+    - url: "http://etcd0:4001"
+# timeout, time to wait on a etcd API request
+      timeout: 5

--- a/scripts/test-infra/etcdv3
+++ b/scripts/test-infra/etcdv3
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+docker service rm etcd0 etcd1 etcd2
+
+docker service create \
+--name etcd0 \
+--network my-net \
+quay.io/coreos/etcd etcd \
+-name etcd0 \
+-advertise-client-urls http://etcd0:2379,http://127.0.0.1:2379 \
+-listen-client-urls http://0.0.0.0:2379 \
+-initial-advertise-peer-urls http://etcd0:2380 \
+-listen-peer-urls http://0.0.0.0:2380 \
+-initial-cluster-token etcd-cluster-1 \
+-initial-cluster etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380 \
+-initial-cluster-state new
+
+sleep 5
+
+docker service create \
+--name etcd1 \
+--network my-net \
+quay.io/coreos/etcd etcd \
+-name etcd1 \
+-advertise-client-urls http://etcd1:2379 \
+-listen-client-urls http://0.0.0.0:2379 \
+-initial-advertise-peer-urls http://etcd1:2380 \
+-listen-peer-urls http://0.0.0.0:2380 \
+-initial-cluster-token etcd-cluster-1 \
+-initial-cluster etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380 \
+-initial-cluster-state new
+
+docker service create \
+--name etcd2 \
+--network my-net \
+quay.io/coreos/etcd etcd \
+-name etcd2 \
+-advertise-client-urls http://etcd2:2379 \
+-listen-client-urls http://0.0.0.0:2379 \
+-initial-advertise-peer-urls http://etcd2:2380 \
+-listen-peer-urls http://0.0.0.0:2380 \
+-initial-cluster-token etcd-cluster-1 \
+-initial-cluster etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380 \
+-initial-cluster-state new
+
+sleep 40
+
+docker service rm dkron-etcd0 dkron-etcd
+
+docker service create \
+--name dkron-etcd0 \
+--network my-net \
+--publish 8080:8080 \
+--container-label beta="0" \
+dkron/dkron:v0.9.3 \
+agent -server \
+-bind=0.0.0.0:8946 \
+-advertise=dkron-etcd0:8946 \
+-backend=etcdv3 \
+-backend-machine=etcd0:2379 \
+-join=dkron-etcd0:8946 \
+-dog-statsd-addr=dd-agent:8125 \
+-dog-statsd-tags=backend:etcd \
+-log-level=debug
+
+sleep 20
+
+docker service create \
+--name dkron-etcd \
+--network my-net \
+--replicas 5 \
+--publish 8081:8080 \
+--container-label beta="0" \
+dkron/dkron:v0.9.3 \
+agent -server \
+-bind=0.0.0.0:8946 \
+-backend=etcdv3 \
+-backend-machine=etcd0:2379 \
+-join=dkron-etcd0:8946 \
+-dog-statsd-addr=dd-agent:8125 \
+-dog-statsd-tags=backend:etcd \
+-log-level=debug

--- a/website/content/basics/configuration.md
+++ b/website/content/basics/configuration.md
@@ -18,7 +18,7 @@ Settings for dkron can be specified in three ways: Using a `config/dkron.json` c
 
 * `--http-addr` - The address where the web UI will be binded. By default `:8080`
 
-* `--backend` - Backend storage to use, etcd, consul, zk (zookeeper) or redis. The default is etcd.
+* `--backend` - Backend storage to use, etcd, etcdv3, consul, zk (zookeeper) or redis. The default is etcd.
 
 * `--backend-machine` - Backend storage servers addresses to connect to. This flag can be specified multiple times. By default `127.0.0.1:2379`
 


### PR DESCRIPTION
In a previous issue about cross data center resilience (https://github.com/victorcoder/dkron/issues/390) you made mention about using mirror-maker with etcd to accomplish cross data center support on the backend.

However, mirror-maker is only supported with etcdv3. The images you are using are running etcdv3, however the client is v2 so you lose the extra functionality with v3. This change gives you the options to use the v3 client with the option `--backend=etcdv3` which is already supported by valkerie.

In order to this to compile you have to use grpc version 1.5.0.