### PR TITLE
jobs static URLs fixed

### DIFF
--- a/dkron/dashboard.go
+++ b/dkron/dashboard.go
@@ -70,7 +70,7 @@ func (a *Agent) dashboardJobsHandler(c *gin.Context) {
 	data := struct {
 		Common *commonDashboardData
 	}{
-		Common: newCommonDashboardData(a, a.config.NodeName, "../../"),
+		Common: newCommonDashboardData(a, a.config.NodeName, "../"),
 	}
 
 	c.HTML(http.StatusOK, "jobs", data)


### PR DESCRIPTION
Trying to use dkron behind nginx on a specific path noticed that static links are wrongly generated in `/dashboard/jobs` with `../../`.

Even though `/dashboard` goes to `/dashboard/`, `/jobs/` goes to `/jobs`, so the proper path is `../` like dashboard.

This effectively allows to change my current nginx location (with a ugly workaround):
```
    location /private/ {
      rewrite /private/(.*) /$1 break;
      proxy_redirect / /private/;
      sub_filter '"/' '"/private/';
      sub_filter '"../../static' '"/private/static';
      sub_filter '"..\/..\/v1' '"\/private\/v1';
      sub_filter '"../../dashboard' '"/private/dashboard';
      sub_filter_once off;
      proxy_pass http://dkronserver/;
    }
```

to

```
    location /private/ {
      rewrite /private/(.*) /$1 break;
      proxy_redirect / /private/;
      proxy_pass http://dkronserver/;
    }
```