### PR TITLE
 Don't query jobs on interval in Dashboard 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ goreleaser:
 	goreleaser --rm-dist
 
 .PHONY: release
-release: clean goreleaser fury
+release: clean goreleaser
 
 .PHONY: clean
 clean:

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -269,7 +269,7 @@ dkron.controller('ExecutionsCtrl', function ($scope, $http, $interval, hideDelay
   };
 });
 
-dkron.controller('IndexCtrl', function ($scope, $http, $interval, $element) {
+dkron.controller('IndexCtrl', function ($scope, $http, $timeout, $element) {
   $scope.options = {
     renderer: 'line',
     interpolation: 'linear'
@@ -310,6 +310,10 @@ dkron.controller('IndexCtrl', function ($scope, $http, $interval, $element) {
     var response = $http.get(DKRON_API_PATH + '/jobs');
     response.success(function (data, status, headers, config) {
       $scope.updateGraph(data);
+
+      $timeout(function () {
+        updateView();
+      }, 2000);
     });
 
     response.error(function (data, status, headers, config) {
@@ -403,10 +407,6 @@ dkron.controller('IndexCtrl', function ($scope, $http, $interval, $element) {
       data: gdata
     };
   }
-
-  $interval(function () {
-    updateView();
-  }, 2000);
 
   updateView();
 });

--- a/website/content/swagger.yaml
+++ b/website/content/swagger.yaml
@@ -8,7 +8,7 @@ produces:
 schemes:
   - http
 info:
-  version: 0.11.2
+  version: 1.0.0-rc
   title: Dkron REST API
   description: |
     You can communicate with Dkron using a RESTful JSON API over HTTP. Dkron nodes usually listen on port `8080` for API requests. All examples in this section assume that you've found a running leader at `localhost:8080`.
@@ -34,16 +34,14 @@ paths:
     get:
       description: |
         List jobs.
-        parameters:
+      parameters:
         - in: query
           name: tags
           type: array
           collectionFormat: multi
           items:
             type: string
-          description: |
-            Filter jobs by tags. Use this param to return only the desired jobs. Use this format ?tags[foo]=bar&tags[baz]=bar
-            this will only return the jobs tagged with the specified tags.
+          description: Filter jobs by tags
       operationId: getJobs
       tags:
         - jobs
@@ -121,6 +119,24 @@ paths:
           type: string
       responses:
         202:
+          description: Successful response
+          schema:
+            $ref: '#/definitions/job'
+  /jobs/{job_name}/toggle:
+    post:
+      description: |
+        Toggle a job.
+      operationId: toggleJob
+      tags:
+        - jobs
+      parameters:
+        - in: path
+          name: job_name
+          description: The job that needs to be toggled.
+          required: true
+          type: string
+      responses:
+        200:
           description: Successful response
           schema:
             $ref: '#/definitions/job'


### PR DESCRIPTION
The dashboard was quering the jobs API every 2 seconds, this cause problems when the jobs call has a greater response time.

This will set a 2 seconds timeout to call jobs after the previous call.

fixes #472 