### PR TITLE
Fix UI run and delete

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -53,12 +53,13 @@ dkron.controller('JobListCtrl', function ($scope, $http, $interval, hideDelay) {
   };
 
   $scope.runJob = function (jobName) {
-    $scope["running_" + jobName] = true;
+    let i = $scope.pagedItems[$scope.currentPage].findIndex(j => j.name === jobName);
+    $scope["running_" + i] = true;
     var response = $http.post(DKRON_API_PATH + '/jobs/' + jobName);
     response.success(function (data, status, headers, config) {
       $('#message').html('<div class="alert alert-success fade in">Success running job ' + jobName + '</div>');
       updateView();
-      $scope["running_" + jobName] = false;
+      $scope["running_" + i] = false;
 
       $(".alert-success").delay(hideDelay).slideUp(200, function () {
         $(".alert").alert('close');
@@ -77,7 +78,6 @@ dkron.controller('JobListCtrl', function ($scope, $http, $interval, hideDelay) {
       window.alert('Json Format Error');
       return
     }
-    $scope["creating_" + job.name] = true;
     var response = $http.post(DKRON_API_PATH + '/jobs', job);
     response.success(function (data, status, headers, config) {
       $('#message').html('<div class="alert alert-success fade in">Success created job ' + job.name + '</div>');
@@ -100,7 +100,6 @@ dkron.controller('JobListCtrl', function ($scope, $http, $interval, hideDelay) {
       window.alert('Json Format Error');
       return
     }
-    $scope["updating_" + job.name] = true;
     var response = $http.post(DKRON_API_PATH + '/jobs', job);
     response.success(function (data, status, headers, config) {
       $('#message').html('<div class="alert alert-success fade in">Success updating job ' + job.name + '</div>');
@@ -117,7 +116,8 @@ dkron.controller('JobListCtrl', function ($scope, $http, $interval, hideDelay) {
   };
 
   $scope.deleteJob = function (jobName) {
-    $scope["deleting_" + jobName] = true;
+    let i = $scope.pagedItems[$scope.currentPage].findIndex(j => j.name === jobName);
+    $scope["deleting_" + i] = true;
     var response = $http.delete(DKRON_API_PATH + '/jobs/' + jobName);
     response.success(function (data, status, headers, config) {
       $('#message').html('<div class="alert alert-success fade in">Successfully removed job ' + jobName + '</div>');
@@ -251,11 +251,11 @@ dkron.controller('JobListCtrl', function ($scope, $http, $interval, hideDelay) {
 
 dkron.controller('ExecutionsCtrl', function ($scope, $http, $interval, hideDelay) {
   $scope.runJob = function (jobName) {
-    $scope["running_" + jobName] = true;
+    $scope["running_job"] = true;
     var response = $http.post(DKRON_API_PATH + '/jobs/' + jobName);
     response.success(function (data, status, headers, config) {
       $('#message').html('<div class="alert alert-success fade in">Success running job ' + jobName + '</div>');
-      $scope["running_" + jobName] = false;
+      $scope["running_job"] = false;
 
       $(".alert-success").delay(hideDelay).slideUp(200, function () {
         $(".alert").alert('close');

--- a/templates/executions.html.tmpl
+++ b/templates/executions.html.tmpl
@@ -1,14 +1,14 @@
 {{define "content"}}
-<div class="container content" ng-controller="JobListCtrl">
+<div class="container content" ng-controller="ExecutionsCtrl">
   <div class="row">
     <div id="message"></div>
   </div>
   <div class="row">
     <h1>Executions</h1>
     <h2>Showing Last 100 Job executions for job {{.JobName}}
-      <a href="#" ng-click="runJob('{{.JobName}}')" ng-show="!running_{{.JobName}}" title="Run"><i class="glyphicon glyphicon-play"
+      <a href="#" ng-click="runJob('{{.JobName}}')" ng-show="!running_job" title="Run"><i class="glyphicon glyphicon-play"
           aria-hidden="true"></i></a>
-      <a href="#"><i class="glyphicon glyphicon-cog normal-right-spinner" ng-show="running_{{.JobName}}"></i></a>
+      <a href="#"><i class="glyphicon glyphicon-cog normal-right-spinner" ng-show="running_job"></i></a>
     </h2>
   </div>
 

--- a/templates/jobs.html.tmpl
+++ b/templates/jobs.html.tmpl
@@ -61,15 +61,15 @@
               <i class="glyphicon glyphicon-eye-open" aria-hidden="true"></i>
             </a>
             &nbsp;
-            <a href="#" ng-click="runJob(job.name)" ng-show="!running_{{`{{ job.name }}`}}" title="Run"><i class="glyphicon glyphicon-play"
+            <a href="#" ng-click="runJob(job.name)" ng-show="!running_{{`{{ $index }}`}}" title="Run"><i class="glyphicon glyphicon-play"
                 aria-hidden="true"></i></a>
-            <a href="#"><i class="glyphicon glyphicon-cog normal-right-spinner" ng-show="running_{{`{{ job.name }}`}}"></i></a>
+            <a href="#"><i class="glyphicon glyphicon-cog normal-right-spinner" ng-show="running_{{`{{ $index }}`}}"></i></a>
             &nbsp;
             <a href="#" ng-click="toggleJob(job.name)" title="Toggle"><i class="glyphicon glyphicon-pause" aria-hidden="true"></i></a>
             &nbsp;
-            <a href="#" data-toggle="modal" data-target="#{{`{{ $index }}`}}-modal-delete" ng-show="!deleting_{{`{{ job.name }}`}}"
+            <a href="#" data-toggle="modal" data-target="#{{`{{ $index }}`}}-modal-delete" ng-show="!deleting_{{`{{ $index }}`}}"
               title="Delete"><i class="glyphicon glyphicon-trash" aria-hidden="true"></i></a>
-            <a href=""><i class="glyphicon glyphicon-cog normal-right-spinner" ng-show="deleting_{{`{{ job.name }}`}}"></i></a>
+            <a href=""><i class="glyphicon glyphicon-cog normal-right-spinner" ng-show="deleting_{{`{{ $index }}`}}"></i></a>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Some job names are not usable as JS variables so reference them by index for ui indicators.

This affects JobList

ExecutionsCtrl was using JobListCtrl wrongly.