### PR TITLE
Fixed swagger.yaml syntax error

### DIFF
--- a/website/content/swagger.yaml
+++ b/website/content/swagger.yaml
@@ -297,9 +297,8 @@ definitions:
         readOnly: false
       dependent_jobs:
         type: array
-        items: {
+        items:
           type: string
-        }
         description: "Array containing the jobs that depends on this one"
         example: ['dependent_job']
         readOnly: true


### PR DESCRIPTION
Parsing swagger.yaml with for instance symfony/yaml gives a syntax error:

`Malformed inline YAML string: { type: string at line 301 (near "  type: string").`