### PR TITLE
Remove mandatory 'command' field because it doesn't exist

### DIFF
--- a/website/content/swagger.yaml
+++ b/website/content/swagger.yaml
@@ -228,7 +228,6 @@ definitions:
     required:
     - name
     - schedule
-    - command
     properties:
       name:
         type: string


### PR DESCRIPTION
The 'command' field appears to have been moved to the 'executor_config' object, but it's still in the list of mandatory fields for the 'job' object.