### PR TITLE
Add --server option for ubuntu

### DIFF
--- a/builder/files/dkron.service
+++ b/builder/files/dkron.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 User=root
-ExecStart=/usr/bin/dkron agent
+ExecStart=/usr/bin/dkron agent --server
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 KillSignal=SIGTERM


### PR DESCRIPTION
I couldn't access to localhost:8080 when I started a command `systemctl start dkron`. I think that It's better to have this options.