### PR TITLE
Fixed sample dkron.yml for slack configuration

### DIFF
--- a/builder/files/dkron.yml
+++ b/builder/files/dkron.yml
@@ -13,8 +13,9 @@
 #   - 10.0.0.2
 #   - 10.0.0.3
 # webhook-url: https://hooks.slack.com/services/XXXXXX/XXXXXXX/XXXXXXXXXXXXXXXXXXXX
-# webhook-payload: "payload={\"text\": \"{{.Report}}\", \"channel\": \"#foo\"}"
-# webhook-headers: Content-Type:application/x-www-form-urlencoded
+# webhook-payload: ""{\"text\":\"A status of {{.JobName}} is {{.Success}}\",\"username\":\"DkronBot\"}""
+# webhook-headers:
+#   - Content-Type:application/json
 # mail-host: email-smtp.eu-west-1.amazonaws.com
 # mail-port: 25
 # mail-username": mailuser


### PR DESCRIPTION
A Payload must be sent as application/json (https://api.slack.com/incoming-webhooks). If I used {{.Report.}} field in payload I got invalid error. Perhaps that is an other bug, so I fixed a payload to not use it temporary.