### PR TITLE
backend TLS support

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -1,6 +1,7 @@
 package dkron
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"expvar"
@@ -12,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"crypto/tls"
 
 	"github.com/abronan/leadership"
 	"github.com/abronan/valkeyrie/store"

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"crypto/tls"
 
 	"github.com/abronan/leadership"
 	"github.com/abronan/valkeyrie/store"
@@ -318,9 +319,15 @@ func (a *Agent) StartServer() {
 			sConfig.Password = a.config.BackendPassword
 		case store.CONSUL:
 			sConfig.Token = a.config.BackendPassword
+			if a.config.BackendTLS {
+				sConfig.TLS = &tls.Config{}
+			}
 		case store.ETCD:
 			sConfig.Username = a.config.BackendUsername
 			sConfig.Password = a.config.BackendPassword
+			if a.config.BackendTLS {
+				sConfig.TLS = &tls.Config{}
+			}
 		}
 		a.Store = NewStore(a.config.Backend, a.config.BackendMachines, a, a.config.Keyspace, &sConfig)
 		if err := a.Store.Healthy(); err != nil {

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -318,6 +318,9 @@ func (a *Agent) StartServer() {
 			sConfig.Password = a.config.BackendPassword
 		case store.CONSUL:
 			sConfig.Token = a.config.BackendPassword
+		case store.ETCD:
+			sConfig.Username = a.config.BackendUsername
+			sConfig.Password = a.config.BackendPassword
 		}
 		a.Store = NewStore(a.config.Backend, a.config.BackendMachines, a, a.config.Keyspace, &sConfig)
 		if err := a.Store.Healthy(); err != nil {

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	HTTPAddr              string `mapstructure:"http-addr"`
 	Backend               store.Backend
 	BackendMachines       []string `mapstructure:"backend-machine"`
+	BackendUsername       string   `mapstructure:"backend-username"`
 	BackendPassword       string   `mapstructure:"backend-password"`
 	Profile               string
 	Interface             string
@@ -77,6 +78,7 @@ func DefaultConfig() *Config {
 		HTTPAddr:          ":8080",
 		Backend:           "boltdb",
 		BackendMachines:   []string{"./dkron.db"},
+		BackendUsername:   "",
 		BackendPassword:   "",
 		Profile:           "lan",
 		Keyspace:          "dkron",
@@ -99,7 +101,8 @@ func ConfigFlagSet() *flag.FlagSet {
 	cmdFlags.String("http-addr", c.HTTPAddr, "Address to bind the UI web server to. Only used when server")
 	cmdFlags.String("backend", string(c.Backend), "Store backend (etcd|etcdv3|consul|zk|redis|boltdb|dynamodb)")
 	cmdFlags.StringSlice("backend-machine", c.BackendMachines, "Store backend machines addresses")
-	cmdFlags.String("backend-password", c.BackendPassword, "Store backend machines password or token, only REDIS/CONSUL")
+	cmdFlags.String("backend-username", c.BackendPassword, "Store backend machines username, only ETCD")
+	cmdFlags.String("backend-password", c.BackendPassword, "Store backend machines password or token, only ETCD/REDIS/CONSUL")
 	cmdFlags.String("profile", c.Profile, "Profile is used to control the timing profiles used")
 	cmdFlags.StringSlice("join", []string{}, "An initial agent to join with. This flag can be specified multiple times")
 	cmdFlags.StringSlice("tag", []string{}, "Tag can be specified multiple times to attach multiple key/value tag pairs to the given node, specified as key=value")

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	BackendMachines       []string `mapstructure:"backend-machine"`
 	BackendUsername       string   `mapstructure:"backend-username"`
 	BackendPassword       string   `mapstructure:"backend-password"`
+	BackendTLS            bool     `mapstructure:"backend-tls"`
 	Profile               string
 	Interface             string
 	AdvertiseAddr         string            `mapstructure:"advertise-addr"`
@@ -80,6 +81,7 @@ func DefaultConfig() *Config {
 		BackendMachines:   []string{"./dkron.db"},
 		BackendUsername:   "",
 		BackendPassword:   "",
+		BackendTLS:        false,
 		Profile:           "lan",
 		Keyspace:          "dkron",
 		LogLevel:          "info",
@@ -103,6 +105,7 @@ func ConfigFlagSet() *flag.FlagSet {
 	cmdFlags.StringSlice("backend-machine", c.BackendMachines, "Store backend machines addresses")
 	cmdFlags.String("backend-username", c.BackendPassword, "Store backend machines username, only ETCD")
 	cmdFlags.String("backend-password", c.BackendPassword, "Store backend machines password or token, only ETCD/REDIS/CONSUL")
+	cmdFlags.Bool("backend-tls", c.BackendTLS, "Use TLS to connect to store backend machines, only ETCD/CONSUL")
 	cmdFlags.String("profile", c.Profile, "Profile is used to control the timing profiles used")
 	cmdFlags.StringSlice("join", []string{}, "An initial agent to join with. This flag can be specified multiple times")
 	cmdFlags.StringSlice("tag", []string{}, "Tag can be specified multiple times to attach multiple key/value tag pairs to the given node, specified as key=value")


### PR DESCRIPTION
As valkeyrie supports TLS for etcd and consul, dkron could expose that option too.

This is a follow up from #538 but I split into a new PR as I was not sure about this feature being as clean, due to not supporting passing all the actual TLS parameters... but I think supporting all those will add too much jibberish to flags with little gain.